### PR TITLE
Refactor to use type guards

### DIFF
--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -1,10 +1,10 @@
 import valueParser from 'postcss-value-parser';
 
 import { assert, isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
-import { isValueWord } from '../../utils/typeGuards.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -71,7 +71,7 @@ const rule = (primary, secondaryOptions) => {
 
 			parsedValue.walk((node) => {
 				const inVal = isAlphaProp && DIGIT.test(node.value);
-				const inFn = node.type === 'function' && ALPHA_FUNCTION_NAME.test(node.value);
+				const inFn = isValueFunction(node) && ALPHA_FUNCTION_NAME.test(node.value);
 				const alpha = inVal ? findAlphaInValue(node) : inFn ? findAlphaInFunction(node) : undefined;
 
 				if (!alpha) return;
@@ -152,7 +152,7 @@ function asNumber(value) {
  * @returns {T | undefined}
  */
 function findAlphaInValue(node) {
-	return node.type === 'word' || node.type === 'function' ? node : undefined;
+	return isValueWord(node) || isValueFunction(node) ? node : undefined;
 }
 
 /**
@@ -160,17 +160,17 @@ function findAlphaInValue(node) {
  * @returns {import('postcss-value-parser').Node | undefined}
  */
 function findAlphaInFunction(node) {
-	const legacySyntax = node.nodes.some(({ type, value }) => type === 'div' && value === ',');
+	const legacySyntax = node.nodes.some((child) => isValueDiv(child) && child.value === ',');
 
 	if (legacySyntax) {
-		const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
+		const args = node.nodes.filter((child) => isValueWord(child) || isValueFunction(child));
 
 		if (args.length === 4) return args[3];
 
 		return undefined;
 	}
 
-	const slashNodeIndex = node.nodes.findIndex(({ type, value }) => type === 'div' && value === '/');
+	const slashNodeIndex = node.nodes.findIndex((child) => isValueDiv(child) && child.value === '/');
 
 	if (slashNodeIndex !== -1) {
 		const nodesAfterSlash = node.nodes.slice(slashNodeIndex + 1, node.nodes.length);

--- a/lib/rules/annotation-no-unknown/index.mjs
+++ b/lib/rules/annotation-no-unknown/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
+import { isValueWord } from '../../utils/typeGuards.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -77,7 +78,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {valueParser.Node} node
 		 */
 		function isAnnotation(node) {
-			return node.type === 'word' && node.value.startsWith('!');
+			return isValueWord(node) && node.value.startsWith('!');
 		}
 	};
 };

--- a/lib/rules/at-rule-empty-line-before/index.mjs
+++ b/lib/rules/at-rule-empty-line-before/index.mjs
@@ -1,9 +1,9 @@
+import { isAtRule, isRoot } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import fixEmptyLinesBefore from '../../utils/fixEmptyLinesBefore.mjs';
 import getPreviousNonSharedLineCommentNode from '../../utils/getPreviousNonSharedLineCommentNode.mjs';
 import hasEmptyLine from '../../utils/hasEmptyLine.mjs';
 import isAfterComment from '../../utils/isAfterComment.mjs';
-import { isAtRule } from '../../utils/typeGuards.mjs';
 import isBlocklessAtRuleAfterBlocklessAtRule from '../../utils/isBlocklessAtRuleAfterBlocklessAtRule.mjs';
 import isBlocklessAtRuleAfterSameNameBlocklessAtRule from '../../utils/isBlocklessAtRuleAfterSameNameBlocklessAtRule.mjs';
 import isFirstNested from '../../utils/isFirstNested.mjs';
@@ -67,7 +67,7 @@ const rule = (primary, secondaryOptions, context) => {
 		const expectation = primary;
 
 		root.walkAtRules((atRule) => {
-			const isNested = atRule.parent && atRule.parent.type !== 'root';
+			const isNested = atRule.parent && !isRoot(atRule.parent);
 
 			// Ignore the first node
 			if (isFirstNodeOfRoot(atRule)) {

--- a/lib/rules/at-rule-property-required-list/index.mjs
+++ b/lib/rules/at-rule-property-required-list/index.mjs
@@ -1,4 +1,5 @@
 import createMapWithSet from '../../utils/createMapWithSet.mjs';
+import { isDeclaration } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
 import report from '../../utils/report.mjs';
@@ -55,7 +56,7 @@ const rule = (primary) => {
 			currentPropList.clear();
 
 			for (const node of nodes) {
-				if (!node || node.type !== 'decl') continue;
+				if (!isDeclaration(node)) continue;
 
 				const propName = node.prop.toLowerCase();
 

--- a/lib/rules/color-function-notation/index.mjs
+++ b/lib/rules/color-function-notation/index.mjs
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
+import { isValueDiv, isValueFunction } from '../../utils/typeGuards.mjs';
 import {
 	legacyNotationColorFunctions,
 	withAlphaAliasColorFunctions,
@@ -7,7 +8,6 @@ import {
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxColorFunction from '../../utils/isStandardSyntaxColorFunction.mjs';
-import { isValueFunction } from '../../utils/typeGuards.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -147,7 +147,7 @@ function containsVariable(nodes) {
  * @returns {node is import('postcss-value-parser').DivNode}
  */
 function isComma(node) {
-	return node.type === 'div' && node.value === ',';
+	return isValueDiv(node) && node.value === ',';
 }
 
 /** @param {import('postcss-value-parser').Node[]} nodes */

--- a/lib/rules/color-named/index.mjs
+++ b/lib/rules/color-named/index.mjs
@@ -1,6 +1,7 @@
 import valueParser from 'postcss-value-parser';
 
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { acceptCustomIdentsProperties } from '../../reference/properties.mjs';
 import { colord } from './colordUtils.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
@@ -81,7 +82,10 @@ const rule = (primary, secondaryOptions) => {
 				const type = node.type;
 				const sourceIndex = node.sourceIndex;
 
-				if (optionsMatches(secondaryOptions, 'ignore', 'inside-function') && type === 'function') {
+				if (
+					optionsMatches(secondaryOptions, 'ignore', 'inside-function') &&
+					isValueFunction(node)
+				) {
 					return false;
 				}
 
@@ -101,7 +105,7 @@ const rule = (primary, secondaryOptions) => {
 				// Check for named colors for "never" option
 				if (
 					primary === 'never' &&
-					type === 'word' &&
+					isValueWord(node) &&
 					namedColorsKeywords.has(value.toLowerCase())
 				) {
 					complain(
@@ -123,13 +127,13 @@ const rule = (primary, secondaryOptions) => {
 				let rawColorString;
 				let colorString;
 
-				if (type === 'function') {
+				if (isValueFunction(node)) {
 					rawColorString = valueParser.stringify(node);
 
 					// First by checking for alternative color function representations ...
 					// Remove all spaces to match what's in `representations`
 					colorString = rawColorString.replace(/\s*([,/()])\s*/g, '$1').replace(/\s{2,}/g, ' ');
-				} else if (type === 'word' && value.startsWith('#')) {
+				} else if (isValueWord(node) && value.startsWith('#')) {
 					// Then by checking for alternative hex representations
 					rawColorString = colorString = value;
 				} else {

--- a/lib/rules/color-no-hex/index.mjs
+++ b/lib/rules/color-no-hex/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isUrlFunction from '../../utils/isUrlFunction.mjs';
+import { isValueWord } from '../../utils/typeGuards.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -59,8 +60,8 @@ const rule = (primary) => {
 /**
  * @param {import('postcss-value-parser').Node} node
  */
-function isHexColor({ type, value }) {
-	return type === 'word' && HEX.test(value);
+function isHexColor(node) {
+	return isValueWord(node) && HEX.test(node.value);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-no-invalid-hex/index.mjs
+++ b/lib/rules/color-no-invalid-hex/index.mjs
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import isStandardSyntaxHexColor from '../../utils/isStandardSyntaxHexColor.mjs';
 import isValidHex from '../../utils/isValidHex.mjs';
@@ -32,10 +33,12 @@ const rule = (primary) => {
 
 			if (!isStandardSyntaxHexColor(decl.value)) return;
 
-			valueParser(decl.value).walk(({ value, type, sourceIndex }) => {
-				if (type === 'function' && value.endsWith('url')) return false;
+			valueParser(decl.value).walk((node) => {
+				const { value, sourceIndex } = node;
 
-				if (type !== 'word') return;
+				if (isValueFunction(node) && value.endsWith('url')) return false;
+
+				if (!isValueWord(node)) return;
 
 				const hexMatch = /^#[\da-z]+/i.exec(value);
 

--- a/lib/rules/container-name-pattern/index.mjs
+++ b/lib/rules/container-name-pattern/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import { atRuleRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueDiv, isValueWord } from '../../utils/typeGuards.mjs';
 import { basicKeywords } from '../../reference/keywords.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
@@ -47,12 +48,14 @@ const rule = (primary) => {
 
 			let isContainerType = false;
 
-			parsedValue.walk(({ sourceIndex, type, value }) => {
+			parsedValue.walk((node) => {
+				const { sourceIndex, value } = node;
+
 				if (isContainerType) return;
 
-				if (type === 'div' && value === '/') isContainerType = true;
+				if (isValueDiv(node) && value === '/') isContainerType = true;
 
-				if (type !== 'word') return false;
+				if (!isValueWord(node)) return false;
 
 				if (cssWideKeywords.has(value.toLowerCase())) return;
 
@@ -71,8 +74,10 @@ const rule = (primary) => {
 
 			const parsedValue = valueParser(params);
 
-			parsedValue.walk(({ sourceIndex, type, value }) => {
-				if (type !== 'word') return false;
+			parsedValue.walk((node) => {
+				const { sourceIndex, value } = node;
+
+				if (!isValueWord(node)) return false;
 
 				if (KEYWORDS.has(value.toLowerCase())) return;
 

--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -1,6 +1,7 @@
 import valueParser from 'postcss-value-parser';
 
 import { atRuleRegexes, mayIncludeRegexes, propertyRegexes } from '../../utils/regexes.mjs';
+import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import report from '../../utils/report.mjs';
@@ -78,7 +79,7 @@ const rule = (primary) => {
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function check(node, decl) {
-			if (node.type === 'function') {
+			if (isValueFunction(node)) {
 				const name = node.value.toLowerCase();
 
 				let args = node.nodes;
@@ -96,7 +97,7 @@ const rule = (primary) => {
 					let foundColon = false;
 
 					node.nodes.forEach((arg) => {
-						if (arg.type === 'div' && arg.value === ':') {
+						if (isValueDiv(arg) && arg.value === ':') {
 							foundColon = true;
 						} else if (!foundColon && isDashedIdent(arg)) {
 							// This is the property name in the query - skip it
@@ -140,8 +141,8 @@ const rule = (primary) => {
 /**
  * @param {Node} node
  */
-function isDashedIdent({ type, value }) {
-	return type === 'word' && value.startsWith('--');
+function isDashedIdent(node) {
+	return isValueWord(node) && node.value.startsWith('--');
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -4,6 +4,7 @@ import { assert, isRegExp, isString } from '../../utils/validateTypes.mjs';
 import arrayEqual from '../../utils/arrayEqual.mjs';
 import { basicKeywords } from '../../reference/keywords.mjs';
 import eachDeclarationBlock from '../../utils/eachDeclarationBlock.mjs';
+import { isValueDiv } from '../../utils/typeGuards.mjs';
 import { longhandSubPropertiesOfShorthandProperties } from '../../reference/properties.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -352,7 +353,7 @@ function commaSeparated(input) {
 	parts.push(current);
 
 	for (const node of valueParser(trimmed).nodes) {
-		if (node.type === 'div' && node.value === ',') {
+		if (isValueDiv(node) && node.value === ',') {
 			current = [];
 			parts.push(current);
 		} else {

--- a/lib/rules/declaration-block-single-line-max-declarations/index.mjs
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.mjs
@@ -1,4 +1,5 @@
 import blockString from '../../utils/blockString.mjs';
+import { isDeclaration } from '../../utils/typeGuards.mjs';
 import { isNumber } from '../../utils/validateTypes.mjs';
 import isSingleLineString from '../../utils/isSingleLineString.mjs';
 import report from '../../utils/report.mjs';
@@ -38,7 +39,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			const decls = ruleNode.nodes.filter((node) => node.type === 'decl');
+			const decls = ruleNode.nodes.filter((node) => isDeclaration(node));
 
 			if (decls.length <= primary) {
 				return;

--- a/lib/rules/declaration-block-single-line-max-declarations/index.mjs
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.mjs
@@ -39,7 +39,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			const decls = ruleNode.nodes.filter((node) => isDeclaration(node));
+			const decls = ruleNode.nodes.filter(isDeclaration);
 
 			if (decls.length <= primary) {
 				return;

--- a/lib/rules/declaration-property-max-values/index.mjs
+++ b/lib/rules/declaration-property-max-values/index.mjs
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
+import { isValueFunction, isValueString, isValueWord } from '../../utils/typeGuards.mjs';
 import { assertNumber } from '../../utils/validateTypes.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
@@ -23,7 +24,7 @@ const meta = {
  * @param {valueParser.Node} node
  */
 const isValueNode = (node) => {
-	return node.type === 'word' || node.type === 'function' || node.type === 'string';
+	return isValueWord(node) || isValueFunction(node) || isValueString(node);
 };
 
 /** @type {import('stylelint').CoreRules[ruleName]} */

--- a/lib/rules/declaration-property-unit-allowed-list/index.mjs
+++ b/lib/rules/declaration-property-unit-allowed-list/index.mjs
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
+import { isValueFunction, isValueString } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDimension from '../../utils/getDimension.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
@@ -65,7 +66,7 @@ const rule = (primary, secondaryOptions) => {
 
 			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
-				if (node.type === 'function') {
+				if (isValueFunction(node)) {
 					if (node.value.toLowerCase() === 'url') {
 						return false;
 					}
@@ -75,7 +76,7 @@ const rule = (primary, secondaryOptions) => {
 					}
 				}
 
-				if (node.type === 'string') {
+				if (isValueString(node)) {
 					return;
 				}
 

--- a/lib/rules/declaration-property-unit-disallowed-list/index.mjs
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.mjs
@@ -4,6 +4,7 @@ import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDimension from '../../utils/getDimension.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
 import isUrlFunction from '../../utils/isUrlFunction.mjs';
+import { isValueString } from '../../utils/typeGuards.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
@@ -61,7 +62,7 @@ const rule = (primary) => {
 					return false;
 				}
 
-				if (node.type === 'string') {
+				if (isValueString(node)) {
 					return;
 				}
 

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
@@ -1,6 +1,7 @@
 import valueParser from 'postcss-value-parser';
 
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueComment, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { colorFunctions } from '../../reference/functions.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
@@ -141,7 +142,7 @@ const rule = (primary, secondaryOptions) => {
 			let isStandardValue = true;
 
 			parsedValue.walk((node) => {
-				if (node.type === 'comment') return;
+				if (isValueComment(node)) return;
 
 				if (!isStandardSyntaxValue(node.value)) isStandardValue = false;
 			});
@@ -152,9 +153,9 @@ const rule = (primary, secondaryOptions) => {
 				const nodeValue = node.value;
 				const lowercasedValue = nodeValue.toLowerCase();
 
-				if (node.type === 'function' && !colorFunctions.has(lowercasedValue)) return false;
+				if (isValueFunction(node) && !colorFunctions.has(lowercasedValue)) return false;
 
-				if (node.type !== 'word') return;
+				if (!isValueWord(node)) return;
 
 				const offset = node.sourceIndex;
 				let fix;

--- a/lib/rules/font-weight-notation/index.mjs
+++ b/lib/rules/font-weight-notation/index.mjs
@@ -4,6 +4,7 @@ import {
 	fontWeightNonNumericKeywords,
 	fontWeightRelativeKeywords,
 } from '../../reference/keywords.mjs';
+import { isValueDiv, isValueWord } from '../../utils/typeGuards.mjs';
 import { mayIncludeRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { assertString } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
@@ -78,7 +79,7 @@ const rule = (primary, secondaryOptions) => {
 			const parsedValue = valueParser(getDeclarationValue(decl));
 			const valueNodes = parsedValue.nodes;
 			const hasNumericFontWeight = valueNodes.some((node, index, nodes) => {
-				return isNumbery(node.value) && !isDivNode(nodes[index - 1]);
+				return isNumbery(node.value) && !isValueDiv(nodes[index - 1]);
 			});
 
 			for (const [index, valueNode] of valueNodes.entries()) {
@@ -191,26 +192,18 @@ const rule = (primary, secondaryOptions) => {
 };
 
 /**
- * @param {Node | undefined} node
- * @returns {boolean}
- */
-function isDivNode(node) {
-	return node !== undefined && node.type === 'div';
-}
-
-/**
  * @param {Node} node
  * @param {number} index
  * @param {Node[]} nodes
  * @returns {boolean}
  */
 function isPossibleFontWeightNode(node, index, nodes) {
-	if (node.type !== 'word') return false;
+	if (!isValueWord(node)) return false;
 
 	// Exclude `<font-size>/<line-height>` format like `16px/3`.
-	if (isDivNode(nodes[index - 1])) return false;
+	if (isValueDiv(nodes[index - 1])) return false;
 
-	if (isDivNode(nodes[index + 1])) return false;
+	if (isValueDiv(nodes[index + 1])) return false;
 
 	return true;
 }

--- a/lib/rules/function-allowed-list/index.mjs
+++ b/lib/rules/function-allowed-list/index.mjs
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
+import { isDeclaration, isValueFunction } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
@@ -48,9 +49,9 @@ const rule = (primary, secondaryOptions) => {
 			if (!decl.value.includes('(')) return;
 
 			valueParser(decl.value).walk((node) => {
-				const { type, sourceIndex, value: funcName } = node;
+				const { sourceIndex, value: funcName } = node;
 
-				if (type !== 'function') {
+				if (!isValueFunction(node)) {
 					return;
 				}
 
@@ -96,7 +97,7 @@ function hasPrevPropertyDeclaration(decl) {
 	let prev = decl.prev();
 
 	while (prev) {
-		if (prev.type === 'decl' && prev.prop.toLowerCase() === prop) {
+		if (isDeclaration(prev) && prev.prop.toLowerCase() === prop) {
 			return true;
 		}
 

--- a/lib/rules/function-disallowed-list/index.mjs
+++ b/lib/rules/function-disallowed-list/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import isStandardSyntaxFunction from '../../utils/isStandardSyntaxFunction.mjs';
+import { isValueFunction } from '../../utils/typeGuards.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -34,9 +35,9 @@ const rule = (primary) => {
 			if (!decl.value.includes('(')) return;
 
 			valueParser(decl.value).walk((node) => {
-				const { type, sourceIndex, value: funcName } = node;
+				const { sourceIndex, value: funcName } = node;
 
-				if (type !== 'function') {
+				if (!isValueFunction(node)) {
 					return;
 				}
 

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.mjs
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import functionArgumentsSearch from '../../utils/functionArgumentsSearch.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
+import { isValueFunction } from '../../utils/typeGuards.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -68,7 +69,7 @@ const rule = (primary) => {
 			if (!LINEAR_GRADIENT_FUNCTION_CALL.test(decl.value)) return;
 
 			valueParser(decl.value).walk((valueNode) => {
-				if (valueNode.type !== 'function') {
+				if (!isValueFunction(valueNode)) {
 					return;
 				}
 

--- a/lib/rules/function-name-case/index.mjs
+++ b/lib/rules/function-name-case/index.mjs
@@ -6,6 +6,7 @@ import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxFunction from '../../utils/isStandardSyntaxFunction.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
+import { isValueFunction } from '../../utils/typeGuards.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -60,7 +61,7 @@ const rule = (primary, secondaryOptions) => {
 			const parsed = valueParser(getDeclarationValue(decl));
 
 			parsed.walk((node) => {
-				if (node.type !== 'function' || !isStandardSyntaxFunction(node)) {
+				if (!isValueFunction(node) || !isStandardSyntaxFunction(node)) {
 					return;
 				}
 

--- a/lib/rules/function-url-quotes/index.mjs
+++ b/lib/rules/function-url-quotes/index.mjs
@@ -1,6 +1,7 @@
 import { isTokenURL, tokenize } from '@csstools/css-tokenizer';
 
 import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
+import { isValueSpace, isValueString, isValueWord } from '../../utils/typeGuards.mjs';
 import functionArgumentsSearch from '../../utils/functionArgumentsSearch.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
@@ -138,7 +139,7 @@ const rule = (primary, secondaryOptions) => {
 		/** @param {FunctionNode} funcNode */
 		function addQuotes(funcNode) {
 			for (const argNode of funcNode.nodes) {
-				if (argNode.type === 'word') {
+				if (isValueWord(argNode)) {
 					argNode.value = `"${argNode.value}"`;
 				}
 			}
@@ -147,7 +148,7 @@ const rule = (primary, secondaryOptions) => {
 		/** @param {FunctionNode} funcNode */
 		function removeQuotes(funcNode) {
 			for (const argNode of funcNode.nodes) {
-				if (argNode.type === 'string') {
+				if (isValueString(argNode)) {
 					// NOTE: We can ignore this error because the test passes.
 					// @ts-expect-error -- TS2322: Type '"word"' is not assignable to type '"string"'.
 					argNode.type = 'word';
@@ -231,8 +232,8 @@ const rule = (primary, secondaryOptions) => {
 		function hasUrlModifier(funcNode) {
 			return funcNode.nodes.some(
 				(n) =>
-					(n.type !== 'string' && n.type !== 'space' && n.type !== 'word') ||
-					(n.type === 'word' && /(?:^|[^\\])\s/.test(n.value)),
+					(!isValueString(n) && !isValueSpace(n) && !isValueWord(n)) ||
+					(isValueWord(n) && /(?:^|[^\\])\s/.test(n.value)),
 			);
 		}
 	};

--- a/lib/rules/hue-degree-notation/index.mjs
+++ b/lib/rules/hue-degree-notation/index.mjs
@@ -5,6 +5,7 @@ import {
 	hueAsThirdComponentColorFunctions,
 	hueColorFunctions,
 } from '../../reference/functions.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
@@ -41,7 +42,7 @@ const rule = (primary) => {
 			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
-				if (node.type !== 'function') return;
+				if (!isValueFunction(node)) return;
 
 				const functionName = node.value.toLowerCase();
 
@@ -98,7 +99,7 @@ const rule = (primary) => {
  * @param {import('postcss-value-parser').FunctionNode} node
  */
 function findHue(node) {
-	const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
+	const args = node.nodes.filter((child) => isValueWord(child) || isValueFunction(child));
 	const value = node.value.toLowerCase();
 
 	// If using relative color syntax, for instance `oklch(from red l c h)`, the

--- a/lib/rules/import-notation/index.mjs
+++ b/lib/rules/import-notation/index.mjs
@@ -1,5 +1,11 @@
 import valueParser from 'postcss-value-parser';
 
+import {
+	isValueFunction,
+	isValueSpace,
+	isValueString,
+	isValueWord,
+} from '../../utils/typeGuards.mjs';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import { atRuleRegexes } from '../../utils/regexes.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
@@ -56,17 +62,18 @@ const rule = (primary) => {
 			const parsed = valueParser(params);
 
 			for (const node of parsed.nodes) {
-				const { sourceEndIndex, type, value } = node;
+				const { sourceEndIndex, value } = node;
 				const endIndex = index + sourceEndIndex;
 				const problem = { node: atRule, index, endIndex, result, ruleName };
 
 				if (primary === 'string') {
-					if (type !== 'function' || value.toLowerCase() !== 'url') continue;
+					if (!isValueFunction(node) || value.toLowerCase() !== 'url') continue;
 
 					const urlFunctionFull = valueParser.stringify(node);
 					const urlFunctionArguments = valueParser.stringify(node.nodes);
-					const quotedUrlFunctionFirstArgument =
-						node.nodes[0]?.type === 'word' ? `"${urlFunctionArguments}"` : urlFunctionArguments;
+					const quotedUrlFunctionFirstArgument = isValueWord(node.nodes[0])
+						? `"${urlFunctionArguments}"`
+						: urlFunctionArguments;
 					const fix = fixer(atRule, quotedUrlFunctionFirstArgument, sourceEndIndex);
 					const message = messages.expected;
 					const messageArgs = [urlFunctionFull, quotedUrlFunctionFirstArgument];
@@ -77,14 +84,15 @@ const rule = (primary) => {
 				}
 
 				if (primary === 'url') {
-					if (type === 'space') return;
+					if (isValueSpace(node)) return;
 
-					if (type !== 'word' && type !== 'string') continue;
+					if (!isValueWord(node) && !isValueString(node)) continue;
 
 					const path = valueParser.stringify(node);
 					const urlFunctionFull = `url(${path})`;
-					const quotedNodeValue =
-						type === 'word' ? `"${value}"` : `${node.quote}${value}${node.quote}`;
+					const quotedNodeValue = isValueWord(node)
+						? `"${value}"`
+						: `${node.quote}${value}${node.quote}`;
 					const fix = fixer(atRule, urlFunctionFull, sourceEndIndex);
 					const message = messages.expected;
 					const messageArgs = [quotedNodeValue, urlFunctionFull];

--- a/lib/rules/layer-name-pattern/index.mjs
+++ b/lib/rules/layer-name-pattern/index.mjs
@@ -2,6 +2,7 @@ import valueParser from 'postcss-value-parser';
 
 import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -37,7 +38,7 @@ const rule = (primary) => {
 			const parsedParams = valueParser(params);
 
 			parsedParams.walk((node) => {
-				check(node.type, node.value, node.sourceIndex, atRule);
+				check(node, atRule);
 			});
 		});
 
@@ -49,22 +50,22 @@ const rule = (primary) => {
 			const parsedParams = valueParser(atRule.params);
 
 			parsedParams.walk((node) => {
-				if (node.type !== 'function' || node.value.toLowerCase() !== 'layer') return;
+				if (!isValueFunction(node) || node.value.toLowerCase() !== 'layer') return;
 
 				for (const child of node.nodes) {
-					check(child.type, child.value, child.sourceIndex, atRule);
+					check(child, atRule);
 				}
 			});
 		});
 
 		/**
-		 * @param {string} type
-		 * @param {string} value
-		 * @param {number} sourceIndex
+		 * @param {import('postcss-value-parser').Node} node
 		 * @param {import('postcss').AtRule} atRule
 		 */
-		function check(type, value, sourceIndex, atRule) {
-			if (type !== 'word') return;
+		function check(node, atRule) {
+			if (!isValueWord(node)) return;
+
+			const { value, sourceIndex } = node;
 
 			if (pattern.test(value)) return;
 

--- a/lib/rules/length-zero-no-unit/index.mjs
+++ b/lib/rules/length-zero-no-unit/index.mjs
@@ -1,7 +1,11 @@
 import valueParser from 'postcss-value-parser';
 
 import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
-import { isValueFunction as isFunction, isValueWord as isWord } from '../../utils/typeGuards.mjs';
+import {
+	isValueDiv as isDiv,
+	isValueFunction as isFunction,
+	isValueWord as isWord,
+} from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
@@ -168,9 +172,7 @@ const rule = (primary, secondaryOptions) => {
 function isLineHeightValue({ prop }, nodes, index) {
 	const lastNode = nodes[index - 1];
 
-	return (
-		prop.toLowerCase() === 'font' && lastNode && lastNode.type === 'div' && lastNode.value === '/'
-	);
+	return prop.toLowerCase() === 'font' && isDiv(lastNode) && lastNode.value === '/';
 }
 
 /**

--- a/lib/rules/length-zero-no-unit/index.mjs
+++ b/lib/rules/length-zero-no-unit/index.mjs
@@ -1,12 +1,8 @@
 import valueParser from 'postcss-value-parser';
 
 import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
-import {
-	isValueDiv as isDiv,
-	isValueFunction as isFunction,
-	isValueWord as isWord,
-} from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
@@ -69,10 +65,10 @@ const rule = (primary, secondaryOptions) => {
 
 			if (isMathFunction(valueNode)) return false;
 
-			if (isFunction(valueNode) && optionsMatches(secondaryOptions, 'ignoreFunctions', value))
+			if (isValueFunction(valueNode) && optionsMatches(secondaryOptions, 'ignoreFunctions', value))
 				return false;
 
-			if (!isWord(valueNode)) return;
+			if (!isValueWord(valueNode)) return;
 
 			const dimension = valueParser.unit(value);
 			const decompositionFailed = dimension === false;
@@ -172,7 +168,7 @@ const rule = (primary, secondaryOptions) => {
 function isLineHeightValue({ prop }, nodes, index) {
 	const lastNode = nodes[index - 1];
 
-	return prop.toLowerCase() === 'font' && isDiv(lastNode) && lastNode.value === '/';
+	return prop.toLowerCase() === 'font' && isValueDiv(lastNode) && lastNode.value === '/';
 }
 
 /**

--- a/lib/rules/lightness-notation/index.mjs
+++ b/lib/rules/lightness-notation/index.mjs
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import {
 	lightnessColorFunctions,
 	lightnessZeroToHundredColorFunctions,
@@ -41,7 +42,7 @@ const rule = (primary) => {
 			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
-				if (node.type !== 'function') return;
+				if (!isValueFunction(node)) return;
 
 				const functionName = node.value.toLowerCase();
 
@@ -153,7 +154,7 @@ function roundToNumberOfDigits(num, value) {
  * @param {import('postcss-value-parser').FunctionNode} node
  */
 function findLightness({ nodes }) {
-	const args = nodes.filter(({ type }) => type === 'word' || type === 'function');
+	const args = nodes.filter((node) => isValueWord(node) || isValueFunction(node));
 	const isRelativeColor = args[0]?.value.toLowerCase() === 'from';
 
 	return isRelativeColor ? args[2] : args[0];

--- a/lib/rules/named-grid-areas-no-invalid/index.mjs
+++ b/lib/rules/named-grid-areas-no-invalid/index.mjs
@@ -4,6 +4,7 @@ import { assert } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import findNotContiguousOrRectangular from './utils/findNotContiguousOrRectangular.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
+import { isValueString } from '../../utils/typeGuards.mjs';
 import { propertyRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -41,8 +42,10 @@ const rule = (primary) => {
 			const areas = [];
 			let reportSent = false;
 
-			valueParser(value).walk(({ sourceIndex, sourceEndIndex, type, value: tokenValue }) => {
-				if (type !== 'string') return;
+			valueParser(value).walk((node) => {
+				const { sourceIndex, sourceEndIndex, value: tokenValue } = node;
+
+				if (!isValueString(node)) return;
 
 				if (tokenValue === '') {
 					complain(messages.expectedToken, [], sourceIndex, sourceEndIndex);

--- a/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
@@ -1,6 +1,7 @@
 import { parse, walk } from 'css-tree';
 
 import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
+import { isAtRule, isRoot, isRule } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
@@ -131,25 +132,22 @@ function hasValidScopingRoot(node, secondaryOptions) {
 
 	while (current) {
 		// If we find a rule in the parent chain, it provides a scoping root
-		if (current.type === 'rule') {
+		if (isRule(current)) {
 			return true;
 		}
 
 		// If we find an @scope at-rule, it provides a scoping root
-		if (current.type === 'atrule' && current.name === 'scope') {
+		if (isAtRule(current) && current.name === 'scope') {
 			return true;
 		}
 
 		// If we find an ignored at-rule, it provides a scoping root
-		if (
-			current.type === 'atrule' &&
-			optionsMatches(secondaryOptions, 'ignoreAtRules', current.name)
-		) {
+		if (isAtRule(current) && optionsMatches(secondaryOptions, 'ignoreAtRules', current.name)) {
 			return true;
 		}
 
 		// If we reach the root without finding a scoping root
-		if (current.type === 'root') {
+		if (isRoot(current)) {
 			return false;
 		}
 

--- a/lib/rules/no-descending-specificity/index.mjs
+++ b/lib/rules/no-descending-specificity/index.mjs
@@ -1,4 +1,5 @@
 import { compare, selectorSpecificity } from '@csstools/selector-specificity';
+import parser from 'postcss-selector-parser';
 
 import { isAtRule, isDeclaration } from '../../utils/typeGuards.mjs';
 import findAtRuleContext from '../../utils/findAtRuleContext.mjs';
@@ -161,14 +162,14 @@ function lastCompoundSelectorWithoutPseudoClasses(selectorNode, result) {
 
 	selectorNode = normalizeSelector(selectorNode, result).node;
 
-	const nodesByCombinator = selectorNode.split((node) => node.type === 'combinator');
+	const nodesByCombinator = selectorNode.split((node) => parser.isCombinator(node));
 	const nodesAfterLastCombinator = nodesByCombinator[nodesByCombinator.length - 1];
 
 	if (!nodesAfterLastCombinator) return undefined;
 
 	const nodesWithoutPseudoClasses = nodesAfterLastCombinator.filter((node) => {
 		return (
-			node.type !== 'pseudo' ||
+			!parser.isPseudo(node) ||
 			node.value.startsWith('::') ||
 			pseudoElements.has(node.value.replaceAll(':', ''))
 		);

--- a/lib/rules/no-duplicate-at-import-rules/index.mjs
+++ b/lib/rules/no-duplicate-at-import-rules/index.mjs
@@ -1,5 +1,12 @@
 import valueParser from 'postcss-value-parser';
 
+import {
+	isValueComment,
+	isValueDiv,
+	isValueFunction,
+	isValueSpace,
+	isValueWord,
+} from '../../utils/typeGuards.mjs';
 import { atRuleRegexes } from '../../utils/regexes.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import isUrlFunction from '../../utils/isUrlFunction.mjs';
@@ -101,26 +108,26 @@ function listImportConditions(params) {
 
 	for (const param of params) {
 		// remove top level whitespace and comments to get a more consistent key
-		if (param.type === 'space' || param.type === 'comment') {
+		if (isValueSpace(param) || isValueComment(param)) {
 			continue;
 		}
 
 		// layer and supports conditions must precede media query conditions
 		if (!media.length) {
 			// @import url(...) layer(base) supports(display: flex)
-			if (param.type === 'function' && (param.value === 'supports' || param.value === 'layer')) {
+			if (isValueFunction(param) && (param.value === 'supports' || param.value === 'layer')) {
 				sharedConditions.push(stringifyCondition(param));
 				continue;
 			}
 
 			// @import url(...) layer
-			if (param.type === 'word' && param.value === 'layer') {
+			if (isValueWord(param) && param.value === 'layer') {
 				sharedConditions.push(stringifyCondition(param));
 				continue;
 			}
 		}
 
-		if (param.type === 'div' && param.value === ',') {
+		if (isValueDiv(param) && param.value === ',') {
 			media.push(stringifyCondition(lastMediaQuery));
 			lastMediaQuery = [];
 			continue;

--- a/lib/rules/no-invalid-position-at-import-rule/index.mjs
+++ b/lib/rules/no-invalid-position-at-import-rule/index.mjs
@@ -1,5 +1,5 @@
+import { isAtRule, isRule } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
-import { isAtRule } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -49,7 +49,7 @@ const rule = (primary, secondaryOptions) => {
 					!(nodeName === 'layer' && typeof node.nodes === 'undefined') &&
 					!optionsMatches(secondaryOptions, 'ignoreAtRules', node.name) &&
 					isStandardSyntaxAtRule(node)) ||
-				(node.type === 'rule' && isStandardSyntaxRule(node))
+				(isRule(node) && isStandardSyntaxRule(node))
 			) {
 				invalidPosition = true;
 

--- a/lib/rules/no-irregular-whitespace/index.mjs
+++ b/lib/rules/no-irregular-whitespace/index.mjs
@@ -13,6 +13,7 @@ import {
 	ruleAfterIndex,
 	ruleBetweenIndex,
 } from '../../utils/nodeFieldIndices.mjs';
+import { isValueComment, isValueString } from '../../utils/typeGuards.mjs';
 
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
@@ -189,7 +190,7 @@ function normalizeValue(value, shouldNormalizeNode) {
  * @returns {string}
  */
 function normalizeAtRule(value) {
-	return normalizeValue(value, (node) => node.type === 'string');
+	return normalizeValue(value, (node) => isValueString(node));
 }
 
 /**.
@@ -204,7 +205,7 @@ function normalizeDecl(value, prop) {
 
 	return normalizeValue(
 		value,
-		(node) => (node.type === 'string' && !shouldIgnore) || node.type === 'comment',
+		(node) => (isValueString(node) && !shouldIgnore) || isValueComment(node),
 	);
 }
 

--- a/lib/rules/no-unknown-custom-properties/index.mjs
+++ b/lib/rules/no-unknown-custom-properties/index.mjs
@@ -2,6 +2,7 @@ import valueParser from 'postcss-value-parser';
 
 import { atRuleRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
+import { isValueDiv } from '../../utils/typeGuards.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -52,7 +53,7 @@ const rule = (primary) => {
 				if (!firstNode || declaredCustomProps.has(firstNode.value)) return;
 
 				// Second node (div) indicates fallback exists in all cases
-				if (secondNode && secondNode.type === 'div') return;
+				if (isValueDiv(secondNode)) return;
 
 				const startIndex = declarationValueIndex(decl);
 

--- a/lib/rules/relative-selector-nesting-notation/index.mjs
+++ b/lib/rules/relative-selector-nesting-notation/index.mjs
@@ -2,6 +2,7 @@ import selectorParser from 'postcss-selector-parser';
 
 import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
+import { isRule } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
@@ -85,7 +86,7 @@ const rule = (primary) => {
  * @returns {boolean}
  */
 function isNestedStyleRule(ruleNode) {
-	return Boolean(findNodeUpToRoot(ruleNode, ({ type }) => type === 'rule'));
+	return Boolean(findNodeUpToRoot(ruleNode, (node) => isRule(node)));
 }
 
 /**

--- a/lib/rules/rule-empty-line-before/index.mjs
+++ b/lib/rules/rule-empty-line-before/index.mjs
@@ -1,3 +1,4 @@
+import { isComment, isRoot, isRule } from '../../utils/typeGuards.mjs';
 import fixEmptyLinesBefore from '../../utils/fixEmptyLinesBefore.mjs';
 import getPreviousNonSharedLineCommentNode from '../../utils/getPreviousNonSharedLineCommentNode.mjs';
 import hasEmptyLine from '../../utils/hasEmptyLine.mjs';
@@ -69,7 +70,7 @@ const rule = (primary, secondaryOptions, context) => {
 			if (optionsMatches(secondaryOptions, 'ignore', 'after-comment')) {
 				const prevNode = ruleNode.prev();
 
-				if (prevNode && prevNode.type === 'comment') {
+				if (isComment(prevNode)) {
 					return;
 				}
 			}
@@ -79,7 +80,7 @@ const rule = (primary, secondaryOptions, context) => {
 				return;
 			}
 
-			const isNested = ruleNode.parent && ruleNode.parent.type !== 'root';
+			const isNested = ruleNode.parent && !isRoot(ruleNode.parent);
 
 			// Optionally ignore the expectation if inside a block
 			if (optionsMatches(secondaryOptions, 'ignore', 'inside-block') && isNested) {
@@ -147,7 +148,7 @@ const rule = (primary, secondaryOptions, context) => {
 function isAfterRule(ruleNode) {
 	const prevNode = getPreviousNonSharedLineCommentNode(ruleNode);
 
-	return prevNode != null && prevNode.type === 'rule';
+	return isRule(prevNode);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -1,5 +1,6 @@
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import isKeyframeRule from '../../utils/isKeyframeRule.mjs';
+import { isRule } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -110,7 +111,7 @@ function declarationIsAChildOfRule(decl, ruleNode) {
 	while (parent) {
 		if (parent === ruleNode) return true;
 
-		if (parent.type === 'rule') return false;
+		if (isRule(parent)) return false;
 
 		parent = parent.parent;
 	}

--- a/lib/rules/selector-disallowed-list/index.mjs
+++ b/lib/rules/selector-disallowed-list/index.mjs
@@ -2,6 +2,7 @@ import { isBoolean, isRegExp, isString } from '../../utils/validateTypes.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
 import isKeyframeRule from '../../utils/isKeyframeRule.mjs';
+import { isRoot } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -64,7 +65,7 @@ const rule = (primary, secondaryOptions) => {
 
 			if (ignoreInsideBlock) {
 				const { parent } = ruleNode;
-				const isInsideBlock = parent && parent.type !== 'root';
+				const isInsideBlock = parent && !isRoot(parent);
 
 				if (isInsideBlock) {
 					return;

--- a/lib/rules/selector-max-pseudo-class/index.mjs
+++ b/lib/rules/selector-max-pseudo-class/index.mjs
@@ -1,3 +1,5 @@
+import parser from 'postcss-selector-parser';
+
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
@@ -39,7 +41,7 @@ const rule = (primary) => {
 			let count = 0;
 
 			selectorNode.walk((childNode) => {
-				if (childNode.type !== 'pseudo') return;
+				if (!parser.isPseudo(childNode)) return;
 
 				// Exclude pseudo elements from the count
 				if (

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -213,11 +213,11 @@ function hasChildCombinatorBefore(node) {
  * @returns {boolean}
  */
 function hasCompoundSelector(node) {
-	if (node.prev() && !isCombinator(node.prev())) {
+	if (node.prev() && !parser.isCombinator(node.prev())) {
 		return true;
 	}
 
-	if (node.next() && !isCombinator(node.next())) {
+	if (node.next() && !parser.isCombinator(node.next())) {
 		return true;
 	}
 
@@ -234,22 +234,12 @@ function hasNextSiblingCombinator(node) {
 
 /**
  * @param {SelectorNode | undefined} node
- * @returns {node is import('postcss-selector-parser').Combinator}
- */
-function isCombinator(node) {
-	if (!node) return false;
-
-	return node.type === 'combinator';
-}
-
-/**
- * @param {SelectorNode | undefined} node
  * @returns {boolean}
  */
 function isDescendantCombinator(node) {
 	if (!node) return false;
 
-	return isCombinator(node) && isString(node.value) && isOnlyWhitespace(node.value);
+	return parser.isCombinator(node) && isString(node.value) && isOnlyWhitespace(node.value);
 }
 
 /**
@@ -259,7 +249,7 @@ function isDescendantCombinator(node) {
 function isChildCombinator(node) {
 	if (!node) return false;
 
-	return isCombinator(node) && node.value === '>';
+	return parser.isCombinator(node) && node.value === '>';
 }
 
 /**
@@ -267,7 +257,7 @@ function isChildCombinator(node) {
  * @returns {boolean}
  */
 function isNextSiblingCombinator(node) {
-	return isCombinator(node) && node.value === '+';
+	return parser.isCombinator(node) && node.value === '+';
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/selector-nested-pattern/index.mjs
+++ b/lib/rules/selector-nested-pattern/index.mjs
@@ -1,6 +1,7 @@
 import { isBoolean, isRegExp, isString } from '../../utils/validateTypes.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
+import { isRule } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
@@ -46,7 +47,7 @@ const rule = (primary, secondaryOptions) => {
 		const splitList = secondaryOptions && secondaryOptions.splitList;
 
 		root.walkRules((ruleNode) => {
-			if (ruleNode.parent && ruleNode.parent.type !== 'rule') {
+			if (ruleNode.parent && !isRule(ruleNode.parent)) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -1,3 +1,5 @@
+import parser from 'postcss-selector-parser';
+
 import {
 	atRulePagePseudoClasses,
 	levelOneAndTwoPseudoElements,
@@ -145,9 +147,9 @@ const rule = (primary, secondaryOptions) => {
 						);
 
 						if (prevPseudoElement) {
-							if (prevPseudoElement.type === 'combinator') crossedCombinator = true;
+							if (parser.isCombinator(prevPseudoElement)) crossedCombinator = true;
 
-							if (prevPseudoElement.type === 'nesting' && !crossedCombinator) {
+							if (parser.isNesting(prevPseudoElement) && !crossedCombinator) {
 								nestingInCompound = true;
 							}
 
@@ -192,7 +194,7 @@ const rule = (primary, secondaryOptions) => {
 		root.walk((node) => {
 			let selector = null;
 
-			if (node.type === 'rule') {
+			if (isRule(node)) {
 				if (!isStandardSyntaxRule(node)) {
 					return;
 				}

--- a/lib/rules/unit-allowed-list/index.mjs
+++ b/lib/rules/unit-allowed-list/index.mjs
@@ -4,6 +4,7 @@ import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIn
 import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import getDimension from '../../utils/getDimension.mjs';
+import { isValueFunction } from '../../utils/typeGuards.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -60,7 +61,7 @@ const rule = (primary, secondaryOptions) => {
 			// by postcss-value-parser
 			value = value.replaceAll('*', ',');
 			valueParser(value).walk((valueNode) => {
-				if (valueNode.type === 'function') {
+				if (isValueFunction(valueNode)) {
 					const valueLowerCase = valueNode.value.toLowerCase();
 
 					// Ignore wrong units within `url` function

--- a/lib/rules/value-keyword-case/index.mjs
+++ b/lib/rules/value-keyword-case/index.mjs
@@ -14,6 +14,7 @@ import {
 	systemColorsKeywords,
 } from '../../reference/keywords.mjs';
 import { isBoolean, isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import getDimension from '../../utils/getDimension.mjs';
@@ -97,7 +98,7 @@ const rule = (primary, secondaryOptions) => {
 
 				// Ignore keywords within `url` and `var` function
 				if (
-					node.type === 'function' &&
+					isValueFunction(node) &&
 					(valueLowerCase === 'url' ||
 						valueLowerCase === 'var' ||
 						valueLowerCase === 'counter' ||
@@ -109,10 +110,7 @@ const rule = (primary, secondaryOptions) => {
 
 				// ignore keywords within ignoreFunctions functions
 
-				if (
-					node.type === 'function' &&
-					optionsMatches(secondaryOptions, 'ignoreFunctions', keyword)
-				) {
+				if (isValueFunction(node) && optionsMatches(secondaryOptions, 'ignoreFunctions', keyword)) {
 					return false;
 				}
 
@@ -120,7 +118,7 @@ const rule = (primary, secondaryOptions) => {
 
 				// Ignore css variables, and hex values, and math operators, and sass interpolation
 				if (
-					node.type !== 'word' ||
+					!isValueWord(node) ||
 					!isStandardSyntaxValue(keyword) ||
 					value.includes('#') ||
 					ignoredCharacters.has(keyword) ||

--- a/lib/utils/__tests__/typeGuards.test.mjs
+++ b/lib/utils/__tests__/typeGuards.test.mjs
@@ -1,0 +1,84 @@
+import postcss from 'postcss';
+import valueParser from 'postcss-value-parser';
+
+import {
+	hasSource,
+	isAtRule,
+	isComment,
+	isDeclaration,
+	isDocument,
+	isRoot,
+	isRule,
+	isValueComment,
+	isValueDiv,
+	isValueFunction,
+	isValueSpace,
+	isValueString,
+	isValueWord,
+} from '../typeGuards.mjs';
+
+const root = postcss.parse('a { color: red; } /* c */ @media {}');
+const rule = root.first;
+const decl = rule.first;
+const comment = root.nodes[1];
+const atRule = root.last;
+
+describe('PostCSS node guards', () => {
+	it('match their node type', () => {
+		expect(isRoot(root)).toBe(true);
+		expect(isRule(rule)).toBe(true);
+		expect(isDeclaration(decl)).toBe(true);
+		expect(isComment(comment)).toBe(true);
+		expect(isAtRule(atRule)).toBe(true);
+	});
+
+	it('reject other node types', () => {
+		expect(isRule(decl)).toBe(false);
+		expect(isComment(rule)).toBe(false);
+		expect(isDocument(root)).toBe(false);
+	});
+
+	it('are null/undefined-safe', () => {
+		expect(isRule(undefined)).toBe(false);
+		expect(isRule(null)).toBe(false);
+		expect(isRoot(rule.parent)).toBe(true);
+		expect(isRule(root.parent)).toBe(false);
+	});
+});
+
+describe('value-parser node guards', () => {
+	const [word, space, fn] = valueParser('10px calc(1px)').nodes;
+	const [, div] = valueParser('a, b').nodes;
+	const [string] = valueParser('"a"').nodes;
+	const [valueComment] = valueParser('/* c */').nodes;
+
+	it('match their node type', () => {
+		expect(isValueWord(word)).toBe(true);
+		expect(isValueSpace(space)).toBe(true);
+		expect(isValueFunction(fn)).toBe(true);
+		expect(isValueDiv(div)).toBe(true);
+		expect(isValueString(string)).toBe(true);
+		expect(isValueComment(valueComment)).toBe(true);
+	});
+
+	it('reject other node types', () => {
+		expect(isValueWord(fn)).toBe(false);
+		expect(isValueString(word)).toBe(false);
+		expect(isValueComment(word)).toBe(false);
+	});
+
+	it('are null/undefined-safe', () => {
+		expect(isValueWord(undefined)).toBe(false);
+		expect(isValueWord(null)).toBe(false);
+		expect(isValueComment(undefined)).toBe(false);
+		expect(isValueString(null)).toBe(false);
+	});
+});
+
+describe('hasSource', () => {
+	it('reflects whether a node carries a source', () => {
+		expect(hasSource(rule)).toBe(true);
+		expect(hasSource(undefined)).toBe(false);
+		expect(hasSource(null)).toBe(false);
+	});
+});

--- a/lib/utils/addSemicolonForEditInfo.mjs
+++ b/lib/utils/addSemicolonForEditInfo.mjs
@@ -1,5 +1,5 @@
 /** @import { Node as PostcssNode } from 'postcss' */
-import { isAtRule } from './typeGuards.mjs';
+import { isAtRule, isDeclaration } from './typeGuards.mjs';
 
 /**
  * Adjust the text in EditInfo to include a semicolon when needed.
@@ -13,7 +13,7 @@ export default function addSemicolonForEditInfo(node, fixData) {
 
 	if (!parent) return fixData;
 
-	if (node.type === 'decl') {
+	if (isDeclaration(node)) {
 		if (parent.raws.semicolon || parent.last !== node) {
 			return {
 				...fixData,

--- a/lib/utils/eachDeclarationBlock.mjs
+++ b/lib/utils/eachDeclarationBlock.mjs
@@ -1,4 +1,4 @@
-import { isAtRule, isRoot, isRule } from './typeGuards.mjs';
+import { isAtRule, isDeclaration, isRoot, isRule } from './typeGuards.mjs';
 
 /** @typedef {import('postcss').Root} Root */
 /** @typedef {import('postcss').Root} Document */
@@ -42,7 +42,7 @@ export default function eachDeclarationBlock(root, callback) {
 			const decls = [];
 
 			for (const node of statement.nodes) {
-				if (node.type === 'decl') {
+				if (isDeclaration(node)) {
 					decls.push(node);
 				}
 

--- a/lib/utils/findAnimationName.mjs
+++ b/lib/utils/findAnimationName.mjs
@@ -1,6 +1,7 @@
 import postcssValueParser from 'postcss-value-parser';
 
 import { animationShorthandKeywords, basicKeywords } from '../reference/keywords.mjs';
+import { isValueFunction, isValueWord } from './typeGuards.mjs';
 import getDimension from './getDimension.mjs';
 import isStandardSyntaxValue from './isStandardSyntaxValue.mjs';
 import isVariable from './isVariable.mjs';
@@ -31,11 +32,11 @@ export default function findAnimationName(value) {
 	valueNodes.walk((valueNode) => {
 		if (shouldBeIgnored) return;
 
-		if (valueNode.type === 'function') {
+		if (isValueFunction(valueNode)) {
 			return false;
 		}
 
-		if (valueNode.type !== 'word') {
+		if (!isValueWord(valueNode)) {
 			return;
 		}
 

--- a/lib/utils/findFontFamily.mjs
+++ b/lib/utils/findFontFamily.mjs
@@ -6,6 +6,7 @@ import {
 	fontShorthandKeywords,
 	fontSizeKeywords,
 } from '../reference/keywords.mjs';
+import { isValueDiv, isValueFunction, isValueSpace } from './typeGuards.mjs';
 import { assert } from './validateTypes.mjs';
 import isNumbery from './isNumbery.mjs';
 import isStandardSyntaxValue from './isStandardSyntaxValue.mjs';
@@ -32,7 +33,7 @@ function joinValueNodes(firstNode, secondNode, charactersBetween) {
  * @param {Node} valueNode
  * @returns {valueNode is postcssValueParser.DivNode & { value: ',' }}
  */
-const isCommaDiv = (valueNode) => valueNode.type === 'div' && valueNode.value === ',';
+const isCommaDiv = (valueNode) => isValueDiv(valueNode) && valueNode.value === ',';
 
 /**
  * Get the font-families within a `font` shorthand property value.
@@ -57,7 +58,7 @@ export default function findFontFamily(value) {
 	let mergeCharacters = null;
 
 	valueNodes.walk((valueNode, index, nodes) => {
-		if (valueNode.type === 'function') {
+		if (isValueFunction(valueNode)) {
 			return false;
 		}
 
@@ -117,7 +118,7 @@ export default function findFontFamily(value) {
 
 		// Detect when a space or comma is dividing a list of font-families, and save the joining character.
 		if (
-			(valueNode.type === 'space' || (valueNode.type === 'div' && valueNode.value !== ',')) &&
+			(isValueSpace(valueNode) || (isValueDiv(valueNode) && valueNode.value !== ',')) &&
 			fontFamilies.length !== 0
 		) {
 			needMergeNodesByValue = true;
@@ -126,7 +127,7 @@ export default function findFontFamily(value) {
 			return;
 		}
 
-		if (valueNode.type === 'space' || valueNode.type === 'div') {
+		if (isValueSpace(valueNode) || isValueDiv(valueNode)) {
 			return;
 		}
 

--- a/lib/utils/functionArgumentsSearch.mjs
+++ b/lib/utils/functionArgumentsSearch.mjs
@@ -1,6 +1,7 @@
 import valueParser from 'postcss-value-parser';
 
 import { assert, isRegExp, isString } from './validateTypes.mjs';
+import { isValueFunction } from './typeGuards.mjs';
 
 /** @typedef {(expression: string, expressionIndex: number, funcNode: valueParser.FunctionNode, parsedValue: valueParser.ParsedValue) => void} Callback */
 
@@ -23,7 +24,7 @@ export default function functionArgumentsSearch(source, functionName, callback) 
 	const parsedValue = valueParser(source);
 
 	return parsedValue.walk((node) => {
-		if (node.type !== 'function') return;
+		if (!isValueFunction(node)) return;
 
 		const { value } = node;
 

--- a/lib/utils/getDimension.mjs
+++ b/lib/utils/getDimension.mjs
@@ -2,6 +2,7 @@ import valueParser from 'postcss-value-parser';
 
 import blurInterpolation from './blurInterpolation.mjs';
 import isStandardSyntaxValue from './isStandardSyntaxValue.mjs';
+import { isValueWord } from './typeGuards.mjs';
 
 /**
  * Get Dimension from value node;
@@ -20,7 +21,7 @@ export default function getDimension(node) {
 	}
 
 	// Ignore non-word nodes
-	if (node.type !== 'word') {
+	if (!isValueWord(node)) {
 		return {
 			unit: null,
 			number: null,

--- a/lib/utils/getNextNonSharedLineCommentNode.mjs
+++ b/lib/utils/getNextNonSharedLineCommentNode.mjs
@@ -1,3 +1,5 @@
+import { isComment } from './typeGuards.mjs';
+
 /** @typedef {import('postcss').Node} Node */
 
 /**
@@ -16,10 +18,10 @@ export default function getNextNonSharedLineCommentNode(node) {
 		return undefined;
 	}
 
-	/** @type {Node | void} */
+	/** @type {Node | undefined} */
 	const nextNode = node.next();
 
-	if (!nextNode || nextNode.type !== 'comment') {
+	if (!isComment(nextNode)) {
 		return nextNode;
 	}
 

--- a/lib/utils/getPreviousNonSharedLineCommentNode.mjs
+++ b/lib/utils/getPreviousNonSharedLineCommentNode.mjs
@@ -1,3 +1,5 @@
+import { isComment } from './typeGuards.mjs';
+
 /** @typedef {import('postcss').Node} Node */
 
 /**
@@ -18,7 +20,7 @@ export default function getPreviousNonSharedLineCommentNode(node) {
 
 	const previousNode = node.prev();
 
-	if (!previousNode || previousNode.type !== 'comment') {
+	if (!isComment(previousNode)) {
 		return previousNode;
 	}
 

--- a/lib/utils/isAfterComment.mjs
+++ b/lib/utils/isAfterComment.mjs
@@ -1,3 +1,4 @@
+import { isComment } from './typeGuards.mjs';
 import isSharedLineComment from './isSharedLineComment.mjs';
 
 /**
@@ -7,7 +8,7 @@ import isSharedLineComment from './isSharedLineComment.mjs';
 export default function isAfterComment(node) {
 	const previousNode = node.prev();
 
-	if (!previousNode || previousNode.type !== 'comment') {
+	if (!isComment(previousNode)) {
 		return false;
 	}
 

--- a/lib/utils/isAfterSingleLineComment.mjs
+++ b/lib/utils/isAfterSingleLineComment.mjs
@@ -1,3 +1,4 @@
+import { isComment } from './typeGuards.mjs';
 import isSharedLineComment from './isSharedLineComment.mjs';
 
 /**
@@ -8,8 +9,7 @@ export default function isAfterSingleLineComment(node) {
 	const prevNode = node.prev();
 
 	return (
-		prevNode !== undefined &&
-		prevNode.type === 'comment' &&
+		isComment(prevNode) &&
 		!isSharedLineComment(prevNode) &&
 		prevNode.source !== undefined &&
 		prevNode.source.start !== undefined &&

--- a/lib/utils/isBlocklessAtRuleAfterBlocklessAtRule.mjs
+++ b/lib/utils/isBlocklessAtRuleAfterBlocklessAtRule.mjs
@@ -7,7 +7,7 @@ import { isAtRule } from './typeGuards.mjs';
  * @returns {boolean}
  */
 export default function isBlocklessAtRuleAfterBlocklessAtRule(atRule) {
-	if (atRule.type !== 'atrule') {
+	if (!isAtRule(atRule)) {
 		return false;
 	}
 

--- a/lib/utils/isContextFunctionalPseudoClass.mjs
+++ b/lib/utils/isContextFunctionalPseudoClass.mjs
@@ -1,3 +1,5 @@
+import parser from 'postcss-selector-parser';
+
 import {
 	aNPlusBOfSNotationPseudoClasses,
 	logicalCombinationsPseudoClasses,
@@ -11,7 +13,7 @@ import {
  * @returns {node is import('postcss-selector-parser').Pseudo} If `true`, the node is a context-functional pseudo-class
  */
 export default function isContextFunctionalPseudoClass(node) {
-	if (node?.type === 'pseudo') {
+	if (parser.isPseudo(node)) {
 		const normalisedParentName = node.value.toLowerCase().replace(/:+/, '');
 
 		return (

--- a/lib/utils/isHexColor.mjs
+++ b/lib/utils/isHexColor.mjs
@@ -1,9 +1,10 @@
 import isValidHex from './isValidHex.mjs';
+import { isValueWord } from './typeGuards.mjs';
 
 /**
  * @param {import('postcss-value-parser').Node} node
  * @returns {boolean}
  */
-export default function isHexColor({ type, value }) {
-	return type === 'word' && isValidHex(value);
+export default function isHexColor(node) {
+	return isValueWord(node) && isValidHex(node.value);
 }

--- a/lib/utils/isMathFunction.mjs
+++ b/lib/utils/isMathFunction.mjs
@@ -1,3 +1,4 @@
+import { isValueFunction } from './typeGuards.mjs';
 import { mathFunctions } from '../reference/functions.mjs';
 
 /**
@@ -7,5 +8,5 @@ import { mathFunctions } from '../reference/functions.mjs';
  * @returns {boolean} If `true`, the node is math function
  */
 export default function isMathFunction(node) {
-	return node.type === 'function' && mathFunctions.has(node.value.toLowerCase());
+	return isValueFunction(node) && mathFunctions.has(node.value.toLowerCase());
 }

--- a/lib/utils/isStandardSyntaxColorFunction.mjs
+++ b/lib/utils/isStandardSyntaxColorFunction.mjs
@@ -1,3 +1,4 @@
+import { isValueFunction, isValueWord } from './typeGuards.mjs';
 import isStandardSyntaxFunction from './isStandardSyntaxFunction.mjs';
 
 /**
@@ -11,10 +12,10 @@ export default function isStandardSyntaxColorFunction(node) {
 
 	// scss can accept a #hex, or $var variables and we need to check all nested fn nodes
 	for (const fnNode of node.nodes) {
-		if (fnNode.type === 'function') return isStandardSyntaxColorFunction(fnNode);
+		if (isValueFunction(fnNode)) return isStandardSyntaxColorFunction(fnNode);
 
 		if (
-			fnNode.type === 'word' &&
+			isValueWord(fnNode) &&
 			(fnNode.value.startsWith('#') || fnNode.value.startsWith('$') || fnNode.value.includes('.$'))
 		)
 			return false;

--- a/lib/utils/isStandardSyntaxCombinator.mjs
+++ b/lib/utils/isStandardSyntaxCombinator.mjs
@@ -1,3 +1,5 @@
+import parser from 'postcss-selector-parser';
+
 /**
  * Check whether a combinator is standard
  *
@@ -6,7 +8,7 @@
  */
 export default function isStandardSyntaxCombinator(node) {
 	// if it's not a combinator, then it's not a standard combinator
-	if (node.type !== 'combinator') {
+	if (!parser.isCombinator(node)) {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxDeclaration.mjs
+++ b/lib/utils/isStandardSyntaxDeclaration.mjs
@@ -1,4 +1,4 @@
-import { isRule } from './typeGuards.mjs';
+import { isAtRule, isRule } from './typeGuards.mjs';
 import isScssVariable from './isScssVariable.mjs';
 
 /**
@@ -22,7 +22,7 @@ export default function isStandardSyntaxDeclaration(decl) {
 	}
 
 	// Less map declaration
-	if (parent && parent.type === 'atrule' && parent.raws.afterName === ':') {
+	if (isAtRule(parent) && parent.raws.afterName === ':') {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxRule.mjs
+++ b/lib/utils/isStandardSyntaxRule.mjs
@@ -1,3 +1,4 @@
+import { isRule } from './typeGuards.mjs';
 import isStandardSyntaxSelector from './isStandardSyntaxSelector.mjs';
 
 /**
@@ -7,7 +8,7 @@ import isStandardSyntaxSelector from './isStandardSyntaxSelector.mjs';
  * @returns {boolean}
  */
 export default function isStandardSyntaxRule(rule) {
-	if (rule.type !== 'rule') {
+	if (!isRule(rule)) {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxTypeSelector.mjs
+++ b/lib/utils/isStandardSyntaxTypeSelector.mjs
@@ -1,3 +1,5 @@
+import parser from 'postcss-selector-parser';
+
 import {
 	aNPlusBNotationPseudoClasses,
 	aNPlusBOfSNotationPseudoClasses,
@@ -39,7 +41,7 @@ export default function isStandardSyntaxTypeSelector(node) {
 	}
 
 	// &-bar is a nesting selector combined with a suffix
-	if (node.prev()?.type === 'nesting') {
+	if (parser.isNesting(node.prev())) {
 		return false;
 	}
 

--- a/lib/utils/typeGuards.mjs
+++ b/lib/utils/typeGuards.mjs
@@ -2,89 +2,105 @@
 /** @typedef {import('postcss').Source} NodeSource */
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is import('postcss').Root}
  */
 export function isRoot(node) {
-	return node.type === 'root';
+	return node?.type === 'root';
 }
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is import('postcss').Rule}
  */
 export function isRule(node) {
-	return node.type === 'rule';
+	return node?.type === 'rule';
 }
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is import('postcss').AtRule}
  */
 export function isAtRule(node) {
-	return node.type === 'atrule';
+	return node?.type === 'atrule';
 }
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is import('postcss').Comment}
  */
 export function isComment(node) {
-	return node.type === 'comment';
+	return node?.type === 'comment';
 }
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is import('postcss').Declaration}
  */
 export function isDeclaration(node) {
-	return node.type === 'decl';
+	return node?.type === 'decl';
 }
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is import('postcss').Document}
  */
 export function isDocument(node) {
-	return node.type === 'document';
+	return node?.type === 'document';
 }
 
 /**
- * @param {import('postcss-value-parser').Node} node
+ * @param {import('postcss-value-parser').Node | null | undefined} node
  * @returns {node is import('postcss-value-parser').DivNode}
  */
 export function isValueDiv(node) {
-	return node.type === 'div';
+	return node?.type === 'div';
 }
 
 /**
- * @param {import('postcss-value-parser').Node} node
+ * @param {import('postcss-value-parser').Node | null | undefined} node
  * @returns {node is import('postcss-value-parser').FunctionNode}
  */
 export function isValueFunction(node) {
-	return node.type === 'function';
+	return node?.type === 'function';
 }
 
 /**
- * @param {import('postcss-value-parser').Node} node
+ * @param {import('postcss-value-parser').Node | null | undefined} node
  * @returns {node is import('postcss-value-parser').SpaceNode}
  */
 export function isValueSpace(node) {
-	return node.type === 'space';
+	return node?.type === 'space';
 }
 
 /**
- * @param {import('postcss-value-parser').Node} node
+ * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @returns {node is import('postcss-value-parser').StringNode}
+ */
+export function isValueString(node) {
+	return node?.type === 'string';
+}
+
+/**
+ * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @returns {node is import('postcss-value-parser').CommentNode}
+ */
+export function isValueComment(node) {
+	return node?.type === 'comment';
+}
+
+/**
+ * @param {import('postcss-value-parser').Node | null | undefined} node
  * @returns {node is import('postcss-value-parser').WordNode}
  */
-export function isValueWord({ type }) {
-	return type === 'word';
+export function isValueWord(node) {
+	return node?.type === 'word';
 }
 
 /**
- * @param {Node} node
+ * @param {Node | null | undefined} node
  * @returns {node is (Node & {source: NodeSource})}
  */
 export function hasSource(node) {
-	return Boolean(node.source);
+	return Boolean(node?.source);
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/9319#discussion_r3331149059

> Is there anything in the PR that needs further explanation?

There was a lot more duplication than my initial search suggested.

This PR refactors to use the PostCSS node, value parser node and selector parser node type guards consistently across rules and utilities.

It makes the PostCSS and value parser node checks undefined-safe, consistent with the selector parser's and our `validateTypes`.

The PR touches a few dozen files, but the refactors are small and consistent, so hopefully it won't be too much trouble to review. I think with these types of refactors, we can treat them as broad strokes and do any finessing later down the line. 

(After we merge this, I'll likely open another refactor PR to abstract duplicated helper functions across our rules.)

 
