### PR TITLE
Refactor to use scoped csstree `walk`

### DIFF
--- a/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
@@ -95,15 +95,11 @@ const rule = (primary, secondaryOptions) => {
 		 */
 		function check(node, ast, offset = 0) {
 			walk(ast, {
-				/**
-				 * @param {import('css-tree').CssNode} cssNode
-				 */
-				enter(cssNode) {
-					if (cssNode.type !== 'NestingSelector') return;
+				visit: 'NestingSelector',
+				enter(nestingSelector) {
+					if (!nestingSelector.loc) return;
 
-					if (!cssNode.loc) return;
-
-					const index = offset + cssNode.loc.start.offset;
+					const index = offset + nestingSelector.loc.start.offset;
 					const endIndex = index + 1;
 
 					report({

--- a/lib/rules/selector-anb-no-unmatchable/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.mjs
@@ -1,4 +1,4 @@
-import { parse } from 'css-tree';
+import { parse, walk } from 'css-tree';
 
 import {
 	aNPlusBNotationPseudoClasses,
@@ -60,27 +60,15 @@ const rule = (primary) => {
 				return;
 			}
 
-			if (cssTreeSelectors.type !== 'SelectorList') return;
-
-			cssTreeSelectors.children.forEach((cssTreeSelector) => {
-				checkSelector(cssTreeSelector);
-			});
-
-			function checkSelector(/** @type {import('css-tree').CssNode} */ selector) {
-				if (selector.type !== 'Selector') {
-					return;
-				}
-
-				selector.children.forEach((selectorChild) => {
+			walk(cssTreeSelectors, {
+				visit: 'PseudoClassSelector',
+				enter(pseudoClassSelector) {
 					if (
-						selectorChild.type !== 'PseudoClassSelector' ||
-						(!aNPlusBNotationPseudoClasses.has(selectorChild.name) &&
-							!aNPlusBOfSNotationPseudoClasses.has(selectorChild.name))
+						!aNPlusBNotationPseudoClasses.has(pseudoClassSelector.name) &&
+						!aNPlusBOfSNotationPseudoClasses.has(pseudoClassSelector.name)
 					) {
 						return;
 					}
-
-					const pseudoClassSelector = selectorChild;
 
 					if (pseudoClassSelector.children === null) {
 						return;
@@ -109,8 +97,8 @@ const rule = (primary) => {
 							});
 						}
 					});
-				});
-			}
+				},
+			});
 		});
 	};
 };

--- a/patches/@types+css-tree+2.3.11.patch
+++ b/patches/@types+css-tree+2.3.11.patch
@@ -2,16 +2,23 @@ diff --git a/node_modules/@types/css-tree/index.d.ts b/node_modules/@types/css-t
 index c005ef3..2303dbb 100644
 --- a/node_modules/@types/css-tree/index.d.ts
 +++ b/node_modules/@types/css-tree/index.d.ts
-@@ -906,13 +906,21 @@ export class Lexer {
+@@ -600,5 +600,6 @@ export type WalkOptions =
+     | WalkOptionsVisit<MediaFeature>
+     | WalkOptionsVisit<MediaQuery>
+     | WalkOptionsVisit<MediaQueryList>
++    | WalkOptionsVisit<NestingSelector>
+     | WalkOptionsVisit<Nth>
+     | WalkOptionsVisit<NumberNode>
+@@ -906,13 +907,21 @@ export class Lexer {
      matchProperty(propertyName: string, value: CssNode | string): LexerMatchResult;
      matchType(typeName: string, value: CssNode | string): LexerMatchResult;
      match(syntax: DSNode | string, value: CssNode | string): LexerMatchResult;
 +    getProperty(propertyName: string, fallbackBasename?: boolean): object | null;
 +    units: Record<string, string[]>;
  }
- 
+
  export const lexer: Lexer;
- 
+
  export function fork(extension: {
 -    atrules?: Record<string, string> | undefined;
 +    atrules?: Record<


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/9322

> Is there anything in the PR that needs further explanation?

I came across these csstree type checks while working on https://github.com/stylelint/stylelint/pull/9322. They pointed to instances where we could use scoped walks, which is now our preferred convention. 
