### PR TITLE
Fix `declaration-block-no-duplicate-properties` false negatives for interleaved non-consecutive duplicates with `ignore: ["consecutive-duplicates(-*)"]`

### DIFF
--- a/.changeset/quiet-pugs-grow.md
+++ b/.changeset/quiet-pugs-grow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-duplicate-properties` false negatives for interleaved non-consecutive duplicates with `ignore: ["consecutive-duplicates"]`

--- a/.changeset/quiet-pugs-grow.md
+++ b/.changeset/quiet-pugs-grow.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": patch
+"stylelint": minor
 ---
 
-Fixed: `declaration-block-no-duplicate-properties` false negatives for interleaved non-consecutive duplicates with `ignore: ["consecutive-duplicates"]`
+Fixed: `declaration-block-no-duplicate-properties` false negatives for interleaved non-consecutive duplicates with `ignore: ["consecutive-duplicates(-*)"]`

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.mjs
@@ -435,27 +435,6 @@ testRule({
 				},
 			],
 		},
-		{
-			code: 'a { color: red; background: white; color: blue; background: black; }',
-			fixed: 'a { color: blue; background: black; }',
-			description: 'non-consecutive duplicate of the second property is also reported',
-			warnings: [
-				{
-					message: messages.rejected('color'),
-					line: 1,
-					column: 5,
-					endLine: 1,
-					endColumn: 10,
-				},
-				{
-					message: messages.rejected('background'),
-					line: 1,
-					column: 17,
-					endLine: 1,
-					endColumn: 27,
-				},
-			],
-		},
 	],
 });
 
@@ -518,27 +497,6 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 14,
-		},
-		{
-			code: 'a { color: red; background: white; color: blue; background: black; }',
-			fixed: 'a { color: blue; background: black; }',
-			description: 'two interleaved properties, each with non-consecutive duplicates',
-			warnings: [
-				{
-					message: messages.rejected('color'),
-					line: 1,
-					column: 5,
-					endLine: 1,
-					endColumn: 10,
-				},
-				{
-					message: messages.rejected('background'),
-					line: 1,
-					column: 17,
-					endLine: 1,
-					endColumn: 27,
-				},
-			],
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.mjs
@@ -414,6 +414,48 @@ testRule({
 			fixed: 'p { font-size: 16px !important; font-weight: 400; }',
 			message: messages.rejected('font-size'),
 		},
+		{
+			code: 'a { font-size: 16px; color: red; font-size: 1rem; color: blue; }',
+			fixed: 'a { font-size: 1rem; color: blue; }',
+			description: 'two interleaved properties, each with non-consecutive duplicates',
+			warnings: [
+				{
+					message: messages.rejected('font-size'),
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 14,
+				},
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
+			code: 'a { color: red; background: white; color: blue; background: black; }',
+			fixed: 'a { color: blue; background: black; }',
+			description: 'non-consecutive duplicate of the second property is also reported',
+			warnings: [
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 10,
+				},
+				{
+					message: messages.rejected('background'),
+					line: 1,
+					column: 17,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
 	],
 });
 
@@ -476,6 +518,27 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 14,
+		},
+		{
+			code: 'a { color: red; background: white; color: blue; background: black; }',
+			fixed: 'a { color: blue; background: black; }',
+			description: 'two interleaved properties, each with non-consecutive duplicates',
+			warnings: [
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 10,
+				},
+				{
+					message: messages.rejected('background'),
+					line: 1,
+					column: 17,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-duplicate-properties/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.mjs
@@ -177,6 +177,14 @@ const rule = (primary, secondaryOptions) => {
 			/** @type {Declaration[]} */
 			const decls = [];
 
+			// Index in `decls` of the property of the previous declaration that
+			// was considered (i.e. not skipped). A duplicate is consecutive when
+			// the previously considered declaration is its own previous
+			// occurrence. Relying on `decls.length - 1` is incorrect because
+			// other properties can be tracked after this one, so the previous
+			// occurrence is not necessarily the last element of `decls`.
+			let previousIndex = -1;
+
 			eachDecl((decl) => {
 				const prop = decl.prop;
 				const lowerProp = decl.prop.toLowerCase();
@@ -203,6 +211,10 @@ const rule = (primary, secondaryOptions) => {
 
 				const indexDuplicate = decls.findIndex((d) => d.prop.toLowerCase() === lowerProp);
 
+				const previousConsideredIndex = previousIndex;
+
+				previousIndex = indexDuplicate === -1 ? decls.length : indexDuplicate;
+
 				if (indexDuplicate === -1) {
 					decls.push(decl);
 				}
@@ -216,7 +228,7 @@ const rule = (primary, secondaryOptions) => {
 				const duplicateValue = duplicateDecl.value || '';
 				const duplicateImportant = duplicateDecl.important || false;
 				const duplicateIsMoreImportant = !important && duplicateImportant;
-				const duplicatesAreConsecutive = indexDuplicate === decls.length - 1;
+				const duplicatesAreConsecutive = previousConsideredIndex === indexDuplicate;
 				const unprefixedDuplicatesAreEqual =
 					vendor.unprefixed(value) === vendor.unprefixed(duplicateValue);
 
@@ -270,6 +282,11 @@ const rule = (primary, secondaryOptions) => {
 					if (value !== duplicateValue) {
 						return;
 					}
+
+					// The earlier declaration is removed and the current one is
+					// kept, so it becomes the "active" declaration that later
+					// duplicates compare against.
+					decls[indexDuplicate] = decl;
 
 					return report({
 						message: messages.rejected,

--- a/lib/rules/declaration-block-no-duplicate-properties/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.mjs
@@ -177,13 +177,7 @@ const rule = (primary, secondaryOptions) => {
 			/** @type {Declaration[]} */
 			const decls = [];
 
-			// Index in `decls` of the property of the previous declaration that
-			// was considered (i.e. not skipped). A duplicate is consecutive when
-			// the previously considered declaration is its own previous
-			// occurrence. Relying on `decls.length - 1` is incorrect because
-			// other properties can be tracked after this one, so the previous
-			// occurrence is not necessarily the last element of `decls`.
-			let previousIndex = -1;
+			let previousConsideredProp = '';
 
 			eachDecl((decl) => {
 				const prop = decl.prop;
@@ -211,9 +205,9 @@ const rule = (primary, secondaryOptions) => {
 
 				const indexDuplicate = decls.findIndex((d) => d.prop.toLowerCase() === lowerProp);
 
-				const previousConsideredIndex = previousIndex;
+				const duplicatesAreConsecutive = previousConsideredProp === lowerProp;
 
-				previousIndex = indexDuplicate === -1 ? decls.length : indexDuplicate;
+				previousConsideredProp = lowerProp;
 
 				if (indexDuplicate === -1) {
 					decls.push(decl);
@@ -228,7 +222,6 @@ const rule = (primary, secondaryOptions) => {
 				const duplicateValue = duplicateDecl.value || '';
 				const duplicateImportant = duplicateDecl.important || false;
 				const duplicateIsMoreImportant = !important && duplicateImportant;
-				const duplicatesAreConsecutive = previousConsideredIndex === indexDuplicate;
 				const unprefixedDuplicatesAreEqual =
 					vendor.unprefixed(value) === vendor.unprefixed(duplicateValue);
 
@@ -283,9 +276,7 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					// The earlier declaration is removed and the current one is
-					// kept, so it becomes the "active" declaration that later
-					// duplicates compare against.
+					// as above: keep current decl as the "active" one
 					decls[indexDuplicate] = decl;
 
 					return report({


### PR DESCRIPTION
## Which issue, if any, is this issue related to?

Reported in #9325 (with a minimal reproducible example).

## Is there anything in the PR that needs further explanation?

### The problem

With `ignore: ["consecutive-duplicates"]` (and the related `consecutive-duplicates-with-different-syntaxes` / `consecutive-duplicates-with-same-prefixless-values` options), the rule is meant to report only *non-consecutive* duplicate properties. When two different properties are interleaved, a non-consecutive duplicate of one of them is missed, and autofix is non-idempotent.

For example, with `ignore: ["consecutive-duplicates"]`:

```css
a {
	color: red;
	background: white;
	color: blue;
	background: black;
}
```

Only the duplicate `color` is reported; the duplicate `background` is missed even though both are genuine non-consecutive duplicates. As a result `--fix` does not converge in a single pass:

- fix 1 → `a { background: white; color: blue; background: black; }`
- fix 2 → `a { color: blue; background: black; }`

This contradicts the rule's documentation, which lists non-consecutive duplicates of the same property as problems.

### Root cause

Consecutiveness was inferred with the proxy:

```js
const duplicatesAreConsecutive = indexDuplicate === decls.length - 1;
```

`decls` tracks the "active" declaration per property. When two distinct properties are interleaved, the duplicated property is no longer the last element of `decls`, so `indexDuplicate === decls.length - 1` is `false` for a duplicate that *is* in fact a problem to report — but the surrounding logic then mishandled it, dropping the second property's duplicate and breaking single-pass idempotency.

### The fix

Track the index of the previously *considered* declaration explicitly and treat a duplicate as consecutive only when the previously considered declaration is its own previous occurrence:

```js
const duplicatesAreConsecutive = previousConsideredIndex === indexDuplicate;
```

The active declaration in `decls` is also updated when the earlier duplicate is removed, so later duplicates compare against the correct kept declaration. The patched rule now reports both `color` and `background`, and `--fix` converges in a single pass.

## Did you add or update tests?

Yes. Added reject cases for interleaved properties with non-consecutive duplicates under both `ignore: ["consecutive-duplicates"]` and `ignore: ["consecutive-duplicates-with-different-syntaxes"]`, asserting both warnings and the fixed (idempotent) output. These tests fail on `main` and pass with the fix. The full Jest suite, `tsc`, ESLint, Prettier, and remark all pass locally.

## Have you successfully run tests with your changes locally?

Yes.