### PR TITLE
Refactor to use `@import` over `@typedef` for simple imports

### DIFF
--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -18,7 +18,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
-/** @typedef {import('postcss-value-parser').Node} Node */
+/** @import { Node } from 'postcss-value-parser' */
 
 // Properties that can receive a custom-ident
 const IGNORED_PROPERTIES = new Set([

--- a/lib/rules/declaration-block-no-duplicate-properties/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.mjs
@@ -24,8 +24,8 @@ const meta = {
 	fixable: true,
 };
 
-/** @typedef {import('css-tree').CssNode} CssNode */
-/** @typedef {import('postcss').Declaration} Declaration */
+/** @import { CssNode } from 'css-tree' */
+/** @import { Declaration } from 'postcss' */
 
 /** @type {(node: CssNode) => node is CssNode & { children: import('css-tree').List<CssNode> }} */
 const hasChildren = (node) => 'children' in node && node.children instanceof List;

--- a/lib/rules/import-notation/index.mjs
+++ b/lib/rules/import-notation/index.mjs
@@ -25,7 +25,7 @@ const meta = {
 	fixable: true,
 };
 
-/** @typedef {import('postcss').AtRule} AtRule */
+/** @import { AtRule } from 'postcss' */
 
 /**
  * @param {AtRule} node

--- a/lib/rules/no-duplicate-at-import-rules/index.mjs
+++ b/lib/rules/no-duplicate-at-import-rules/index.mjs
@@ -78,7 +78,7 @@ const rule = (primary) => {
 	};
 };
 
-/** @typedef { import('postcss-value-parser').Node } Node */
+/** @import { Node } from 'postcss-value-parser' */
 
 /**
  * @param {Node | Array<Node>} node

--- a/lib/rules/selector-max-specificity/index.mjs
+++ b/lib/rules/selector-max-specificity/index.mjs
@@ -23,7 +23,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-max-specificity',
 };
 
-/** @typedef {import('@csstools/selector-specificity').Specificity} Specificity */
+/** @import { Specificity } from '@csstools/selector-specificity' */
 
 /**
  * Return a zero specificity. We need a new instance each time so that it can mutated.

--- a/lib/rules/selector-not-notation/index.mjs
+++ b/lib/rules/selector-not-notation/index.mjs
@@ -20,12 +20,8 @@ const meta = {
 	fixable: true,
 };
 
-/** @typedef {import('postcss-selector-parser').Node} Node */
-/** @typedef {import('postcss-selector-parser').Selector} Selector */
-/** @typedef {import('postcss-selector-parser').Pseudo} Pseudo */
-/** @typedef {import('postcss-selector-parser').Root} Root */
-/** @typedef {import('postcss').Rule} Rule */
-/** @typedef {import('stylelint').Range} Range */
+/** @import { Node, Selector, Pseudo, Root } from 'postcss-selector-parser' */
+/** @import { Rule } from 'postcss' */
 
 /**
  * @param {Node} node

--- a/lib/unscopedDisables.mjs
+++ b/lib/unscopedDisables.mjs
@@ -4,7 +4,7 @@ import optionsMatches from './utils/optionsMatches.mjs';
 import reportCommentProblem from './utils/reportCommentProblem.mjs';
 import validateDisableSettings from './validateDisableSettings.mjs';
 
-/** @typedef {import('postcss').Node} Node */
+/** @import { Node } from 'postcss' */
 
 /** @param {import('stylelint').PostcssResult} postcssResult */
 export default function reportUnscopedDisables(postcssResult) {

--- a/lib/utils/eachDeclarationBlock.mjs
+++ b/lib/utils/eachDeclarationBlock.mjs
@@ -1,10 +1,6 @@
 import { isAtRule, isDeclaration, isRoot, isRule } from './typeGuards.mjs';
 
-/** @typedef {import('postcss').Root} Root */
-/** @typedef {import('postcss').Root} Document */
-/** @typedef {import('postcss').Node} PostcssNode */
-/** @typedef {import('postcss').Container} PostcssContainerNode */
-/** @typedef {import('postcss').Declaration} Declaration */
+/** @import { Root, Root as Document, Node as PostcssNode, Container as PostcssContainerNode, Declaration } from 'postcss' */
 /** @typedef {(callbackFn: (decl: Declaration, index: number, decls: Declaration[]) => void) => void} EachDeclaration */
 
 /**

--- a/lib/utils/findAnimationName.mjs
+++ b/lib/utils/findAnimationName.mjs
@@ -6,7 +6,7 @@ import getDimension from './getDimension.mjs';
 import isStandardSyntaxValue from './isStandardSyntaxValue.mjs';
 import isVariable from './isVariable.mjs';
 
-/** @typedef {import('postcss-value-parser').Node} Node */
+/** @import { Node } from 'postcss-value-parser' */
 
 /**
  * Get the animation name within an `animation` shorthand property value.

--- a/lib/utils/findFontFamily.mjs
+++ b/lib/utils/findFontFamily.mjs
@@ -15,7 +15,7 @@ import isVariable from './isVariable.mjs';
 
 const nodeTypesToCheck = new Set(['word', 'string', 'space', 'div']);
 
-/** @typedef {import('postcss-value-parser').Node} Node */
+/** @import { Node } from 'postcss-value-parser' */
 
 /**
  * @param {Node} firstNode

--- a/lib/utils/findMediaFeatureNames.mjs
+++ b/lib/utils/findMediaFeatureNames.mjs
@@ -11,8 +11,8 @@ import {
 	parseCommaSeparatedListOfComponentValues,
 } from '@csstools/css-parser-algorithms';
 
+/** @import { TokenIdent } from '@csstools/css-tokenizer' */
 /** @typedef {Array<import('@csstools/media-query-list-parser').MediaQuery>} MediaQueryList */
-/** @typedef {import('@csstools/css-tokenizer').TokenIdent} TokenIdent */
 /** @typedef {{ stringify: () => string }} MediaQuerySerializer */
 
 const rangeFeatureOperator = /[<>=]/;

--- a/lib/utils/getFileIgnorer.mjs
+++ b/lib/utils/getFileIgnorer.mjs
@@ -5,9 +5,7 @@ import ignore from 'ignore';
 import { DEFAULT_IGNORE_FILENAME } from '../constants.mjs';
 
 /**
- * @typedef {import('stylelint').LinterOptions} LinterOptions
- *
- * @param {Pick<LinterOptions, 'ignorePath' | 'ignorePattern'> & { cwd: string }} options
+ * @param {Pick<import('stylelint').LinterOptions, 'ignorePath' | 'ignorePattern'> & { cwd: string }} options
  * @returns {import('ignore').Ignore}
  */
 export default function getFileIgnorer({ ignorePath, ignorePattern, cwd }) {

--- a/lib/utils/getNextNonSharedLineCommentNode.mjs
+++ b/lib/utils/getNextNonSharedLineCommentNode.mjs
@@ -1,6 +1,6 @@
 import { isComment } from './typeGuards.mjs';
 
-/** @typedef {import('postcss').Node} Node */
+/** @import { Node } from 'postcss' */
 
 /**
  * @param {Node | void} node

--- a/lib/utils/getPreviousNonSharedLineCommentNode.mjs
+++ b/lib/utils/getPreviousNonSharedLineCommentNode.mjs
@@ -1,6 +1,6 @@
 import { isComment } from './typeGuards.mjs';
 
-/** @typedef {import('postcss').Node} Node */
+/** @import { Node } from 'postcss' */
 
 /**
  * @param {Node} node

--- a/lib/utils/isSharedLineComment.mjs
+++ b/lib/utils/isSharedLineComment.mjs
@@ -2,7 +2,7 @@ import { isComment, isRoot } from './typeGuards.mjs';
 import getNextNonSharedLineCommentNode from './getNextNonSharedLineCommentNode.mjs';
 import getPreviousNonSharedLineCommentNode from './getPreviousNonSharedLineCommentNode.mjs';
 
-/** @typedef {import('postcss').Node} PostcssNode */
+/** @import { Node as PostcssNode } from 'postcss' */
 
 /**
  * @param {PostcssNode | void} a

--- a/lib/utils/setAtRuleParams.mjs
+++ b/lib/utils/setAtRuleParams.mjs
@@ -1,4 +1,4 @@
-/** @typedef {import('postcss').AtRule} AtRule */
+/** @import { AtRule } from 'postcss' */
 
 /**
  * @param {AtRule} atRule

--- a/lib/utils/setDeclarationValue.mjs
+++ b/lib/utils/setDeclarationValue.mjs
@@ -1,4 +1,4 @@
-/** @typedef {import('postcss').Declaration} Declaration */
+/** @import { Declaration } from 'postcss' */
 
 /**
  * @param {Declaration} decl

--- a/lib/utils/typeGuards.mjs
+++ b/lib/utils/typeGuards.mjs
@@ -1,8 +1,13 @@
-/** @typedef {import('postcss').Node} Node */
-/** @typedef {import('postcss').Source} NodeSource */
+/** @import { Node as PostcssNode } from 'postcss' */
+/** @import { Node as ValueNode } from 'postcss-value-parser' */
 
 /**
- * @param {Node | null | undefined} node
+ * @template T
+ * @typedef {T | null | undefined} Maybe
+ */
+
+/**
+ * @param {Maybe<PostcssNode>} node
  * @returns {node is import('postcss').Root}
  */
 export function isRoot(node) {
@@ -10,7 +15,7 @@ export function isRoot(node) {
 }
 
 /**
- * @param {Node | null | undefined} node
+ * @param {Maybe<PostcssNode>} node
  * @returns {node is import('postcss').Rule}
  */
 export function isRule(node) {
@@ -18,7 +23,7 @@ export function isRule(node) {
 }
 
 /**
- * @param {Node | null | undefined} node
+ * @param {Maybe<PostcssNode>} node
  * @returns {node is import('postcss').AtRule}
  */
 export function isAtRule(node) {
@@ -26,7 +31,7 @@ export function isAtRule(node) {
 }
 
 /**
- * @param {Node | null | undefined} node
+ * @param {Maybe<PostcssNode>} node
  * @returns {node is import('postcss').Comment}
  */
 export function isComment(node) {
@@ -34,7 +39,7 @@ export function isComment(node) {
 }
 
 /**
- * @param {Node | null | undefined} node
+ * @param {Maybe<PostcssNode>} node
  * @returns {node is import('postcss').Declaration}
  */
 export function isDeclaration(node) {
@@ -42,7 +47,7 @@ export function isDeclaration(node) {
 }
 
 /**
- * @param {Node | null | undefined} node
+ * @param {Maybe<PostcssNode>} node
  * @returns {node is import('postcss').Document}
  */
 export function isDocument(node) {
@@ -50,7 +55,7 @@ export function isDocument(node) {
 }
 
 /**
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<ValueNode>} node
  * @returns {node is import('postcss-value-parser').DivNode}
  */
 export function isValueDiv(node) {
@@ -58,7 +63,7 @@ export function isValueDiv(node) {
 }
 
 /**
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<ValueNode>} node
  * @returns {node is import('postcss-value-parser').FunctionNode}
  */
 export function isValueFunction(node) {
@@ -66,7 +71,7 @@ export function isValueFunction(node) {
 }
 
 /**
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<ValueNode>} node
  * @returns {node is import('postcss-value-parser').SpaceNode}
  */
 export function isValueSpace(node) {
@@ -74,7 +79,7 @@ export function isValueSpace(node) {
 }
 
 /**
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<ValueNode>} node
  * @returns {node is import('postcss-value-parser').StringNode}
  */
 export function isValueString(node) {
@@ -82,7 +87,7 @@ export function isValueString(node) {
 }
 
 /**
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<ValueNode>} node
  * @returns {node is import('postcss-value-parser').CommentNode}
  */
 export function isValueComment(node) {
@@ -90,7 +95,7 @@ export function isValueComment(node) {
 }
 
 /**
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<ValueNode>} node
  * @returns {node is import('postcss-value-parser').WordNode}
  */
 export function isValueWord(node) {
@@ -98,8 +103,8 @@ export function isValueWord(node) {
 }
 
 /**
- * @param {Node | null | undefined} node
- * @returns {node is (Node & {source: NodeSource})}
+ * @param {Maybe<PostcssNode>} node
+ * @returns {node is (PostcssNode & {source: import('postcss').Source})}
  */
 export function hasSource(node) {
 	return Boolean(node?.source);

--- a/lib/utils/validateOptions.mjs
+++ b/lib/utils/validateOptions.mjs
@@ -9,8 +9,7 @@ const REPORT_OPTIONS = new Set([
 	'reportUnscopedDisables',
 ]);
 
-/** @typedef {import('stylelint').RuleOptions} RuleOptions */
-/** @typedef {import('stylelint').RuleOptionsPossible} RuleOptionsPossible */
+/** @import { RuleOptions, RuleOptionsPossible } from 'stylelint' */
 
 /**
  * @type {import('stylelint').Utils['validateOptions']}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/9322#discussion_r3333580928

> Is there anything in the PR that needs further explanation?

> also `import('postcss-value-parser').Node` in this file.

@ybiquitous I just realised what you meant by this... consolidate them into a single `@import` to be consistent with the postcss one, right?

I've done that as part of this PR, too. And included a template to make each guard's docs, arguably, easier to read.
