### PR TITLE
Skip changeset verification on fork PRs CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           YARN_ENABLE_HARDENED_MODE: 0 # https://yarnpkg.com/features/security#hardened-mode
 
       - name: Verify changeset
+        # Skip fork PRs due to GitHub token permissions.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           npm run changeset
           npm run lint:md


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR prevents CI failures at the verification step on fork PRs because Changesets requires a GitHub token with the `read:user` and `repo:status` permissions. A token on fork PRs doesn't have the permissions.