### PR TITLE
Add a helper to determine if `root` should be excluded when considering `referenceRoots`

### DIFF
--- a/lib/__tests__/fixtures/config-reference-files/embedded-current.css
+++ b/lib/__tests__/fixtures/config-reference-files/embedded-current.css
@@ -1,0 +1,7 @@
+@property --token {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 1px;
+}
+
+a { --token: 1px; }

--- a/lib/__tests__/fixtures/config-reference-files/embedded-entrypoint.css
+++ b/lib/__tests__/fixtures/config-reference-files/embedded-entrypoint.css
@@ -1,0 +1,7 @@
+@import url("./embedded-current.css");
+
+@property --token {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: red;
+}

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -344,6 +344,22 @@ describe('standalone with referenceFiles', () => {
 			expect(results).toHaveLength(1);
 			expect(results[0].warnings).toHaveLength(0);
 		});
+
+		it('uses the embedded source order when a reference bundle includes the linted file', async () => {
+			const { results } = await standalone({
+				files: [path.join(fixturesPath, 'embedded-current.css')],
+				config: {
+					referenceFiles: [{ files: ['embedded-entrypoint.css'], loader: 'postcss-import' }],
+					rules: { 'declaration-property-value-no-unknown': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].rule).toBe('declaration-property-value-no-unknown');
+			expect(results[0].warnings[0].text).toContain('Unknown value "1px" for property "--token"');
+		});
 	});
 
 	describe('plugin access', () => {

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -17,6 +17,7 @@ import getLexer from '../../utils/getLexer.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
 import { isDeclaration } from '../../utils/typeGuards.mjs';
 import isDescriptorDeclaration from '../../utils/isDescriptorDeclaration.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
 import isStandardSyntaxProperty from '../../utils/isStandardSyntaxProperty.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
@@ -104,8 +105,11 @@ const rule = (primary, secondaryOptions) => {
 		const typedCustomPropertyNames = new Map();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const rootsToCheck = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [...referenceRoots, root];
 
-		for (const rootNode of [...referenceRoots, root]) {
+		for (const rootNode of rootsToCheck) {
 			rootNode.walkAtRules(atRuleRegexes.propertyName, (atRule) => {
 				const propName = atRule.params.trim();
 

--- a/lib/rules/no-unknown-animations/index.mjs
+++ b/lib/rules/no-unknown-animations/index.mjs
@@ -2,6 +2,7 @@ import { animationNameKeywords } from '../../reference/keywords.mjs';
 import { atRuleRegexes } from '../../utils/regexes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import findAnimationName from '../../utils/findAnimationName.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -28,8 +29,11 @@ const rule = (primary) => {
 		const declaredAnimations = new Set();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const rootsToCheck = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [root, ...referenceRoots];
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of rootsToCheck) {
 			rootNode.walkAtRules(atRuleRegexes.keyframesName, (atRule) => {
 				declaredAnimations.add(atRule.params);
 			});

--- a/lib/rules/no-unknown-custom-media/index.mjs
+++ b/lib/rules/no-unknown-custom-media/index.mjs
@@ -2,6 +2,7 @@ import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
 import { isMediaFeature, isMediaQueryInvalid } from '@csstools/media-query-list-parser';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import isCustomMediaQuery from '../../utils/isCustomMediaQuery.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import parseCustomMediaQuery from '../../utils/parseCustomMediaQuery.mjs';
 import parseMediaQuery from '../../utils/parseMediaQuery.mjs';
 import report from '../../utils/report.mjs';
@@ -28,8 +29,11 @@ const rule = (primary) => {
 		const declaredCustomMediaQueries = new Set();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const rootsToCheck = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [root, ...referenceRoots];
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of rootsToCheck) {
 			rootNode.walkAtRules(atRuleRegexes.customMediaName, (atRule) => {
 				const customMediaQuery = parseCustomMediaQuery(atRule);
 

--- a/lib/rules/no-unknown-custom-properties/index.mjs
+++ b/lib/rules/no-unknown-custom-properties/index.mjs
@@ -2,6 +2,7 @@ import valueParser from 'postcss-value-parser';
 
 import { atRuleRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import { isValueDiv } from '../../utils/typeGuards.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import report from '../../utils/report.mjs';
@@ -29,8 +30,11 @@ const rule = (primary) => {
 		const declaredCustomProps = new Set();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const rootsToCheck = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [root, ...referenceRoots];
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of rootsToCheck) {
 			rootNode.walkAtRules(atRuleRegexes.propertyName, ({ params }) => {
 				declaredCustomProps.add(params);
 			});

--- a/lib/utils/isRootIncludedInReferenceRoots.mjs
+++ b/lib/utils/isRootIncludedInReferenceRoots.mjs
@@ -1,0 +1,46 @@
+import path from 'node:path';
+
+import normalizeFilePath from './normalizeFilePath.mjs';
+
+/** @import { Root, ChildNode } from 'postcss' */
+
+/**
+ * Check whether a linted root is already embedded in any reference root.
+ *
+ * @param {Root} root
+ * @param {Root[]} referenceRoots
+ * @returns {boolean}
+ */
+export default function isRootIncludedInReferenceRoots(root, referenceRoots) {
+	const rootFile = getAbsoluteSourcePath(root);
+
+	if (!rootFile) return false;
+
+	return referenceRoots.some((referenceRoot) => {
+		if (getAbsoluteSourcePath(referenceRoot) === rootFile) return true;
+
+		let isIncluded = false;
+
+		referenceRoot.walk((node) => {
+			if (getAbsoluteSourcePath(node) !== rootFile) return;
+
+			isIncluded = true;
+
+			return false;
+		});
+
+		return isIncluded;
+	});
+}
+
+/**
+ * @param {Root | ChildNode} node
+ * @returns {string | undefined}
+ */
+function getAbsoluteSourcePath(node) {
+	const from = node.source?.input.from;
+
+	if (!from) return undefined;
+
+	return normalizeFilePath(path.resolve(from));
+}


### PR DESCRIPTION
Fixes #9297

## Summary

- Add a helper that detects when the linted root is already present in `referenceRoots` by comparing absolute `source.input.from` paths.
- Use the helper in the reference-aware rules so an embedded root keeps its source order from the reference bundle.
- Add a regression test for a PostCSS import bundle where a later `@property` definition should win over the imported file's standalone root.

## Testing

- `npm run test-only -- lib/__tests__/referenceFiles.test.mjs`
- `npm run test-only -- lib/__tests__/referenceFiles.test.mjs lib/rules/no-unknown-animations/__tests__/index.mjs lib/rules/no-unknown-custom-media/__tests__/index.mjs lib/rules/no-unknown-custom-properties/__tests__/index.mjs lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs`
- `npx prettier --check lib/__tests__/referenceFiles.test.mjs lib/rules/no-unknown-animations/index.mjs lib/rules/no-unknown-custom-media/index.mjs lib/rules/no-unknown-custom-properties/index.mjs lib/rules/declaration-property-value-no-unknown/index.mjs lib/utils/isRootIncludedInReferenceRoots.mjs lib/__tests__/fixtures/config-reference-files/embedded-current.css lib/__tests__/fixtures/config-reference-files/embedded-entrypoint.css`
- `npx eslint lib/__tests__/referenceFiles.test.mjs lib/rules/no-unknown-animations/index.mjs lib/rules/no-unknown-custom-media/index.mjs lib/rules/no-unknown-custom-properties/index.mjs lib/rules/declaration-property-value-no-unknown/index.mjs lib/utils/isRootIncludedInReferenceRoots.mjs --max-warnings=0`
- `git diff --check`

`npm run lint:types` currently fails on unrelated upstream type errors in `lib/rules/nesting-selector-no-missing-scoping-root/index.mjs`, `lib/rules/property-no-unknown/index.mjs`, and `lib/utils/getLexer.mjs`.