### PR TITLE
Refactor to reuse shared utilities

### DIFF
--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -1,9 +1,11 @@
 import valueParser from 'postcss-value-parser';
 
 import { assert, isRegExp, isString } from '../../utils/validateTypes.mjs';
-import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
+import isComma from '../../utils/isComma.mjs';
+import isSlash from '../../utils/isSlash.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -160,7 +162,7 @@ function findAlphaInValue(node) {
  * @returns {import('postcss-value-parser').Node | undefined}
  */
 function findAlphaInFunction(node) {
-	const legacySyntax = node.nodes.some((child) => isValueDiv(child) && child.value === ',');
+	const legacySyntax = node.nodes.some((child) => isComma(child));
 
 	if (legacySyntax) {
 		const args = node.nodes.filter((child) => isValueWord(child) || isValueFunction(child));
@@ -170,7 +172,7 @@ function findAlphaInFunction(node) {
 		return undefined;
 	}
 
-	const slashNodeIndex = node.nodes.findIndex((child) => isValueDiv(child) && child.value === '/');
+	const slashNodeIndex = node.nodes.findIndex((child) => isSlash(child));
 
 	if (slashNodeIndex !== -1) {
 		const nodesAfterSlash = node.nodes.slice(slashNodeIndex + 1, node.nodes.length);

--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -172,7 +172,7 @@ function findAlphaInFunction(node) {
 		return undefined;
 	}
 
-	const slashNodeIndex = node.nodes.findIndex((child) => isSlash(child));
+	const slashNodeIndex = node.nodes.findIndex(isSlash);
 
 	if (slashNodeIndex !== -1) {
 		const nodesAfterSlash = node.nodes.slice(slashNodeIndex + 1, node.nodes.length);

--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -162,7 +162,7 @@ function findAlphaInValue(node) {
  * @returns {import('postcss-value-parser').Node | undefined}
  */
 function findAlphaInFunction(node) {
-	const legacySyntax = node.nodes.some((child) => isComma(child));
+	const legacySyntax = node.nodes.some(isComma);
 
 	if (legacySyntax) {
 		const args = node.nodes.filter((child) => isValueWord(child) || isValueFunction(child));

--- a/lib/rules/color-function-notation/index.mjs
+++ b/lib/rules/color-function-notation/index.mjs
@@ -1,13 +1,15 @@
 import valueParser from 'postcss-value-parser';
 
-import { isValueDiv, isValueFunction } from '../../utils/typeGuards.mjs';
 import {
 	legacyNotationColorFunctions,
 	withAlphaAliasColorFunctions,
 } from '../../reference/functions.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
+import isComma from '../../utils/isComma.mjs';
+import isSlash from '../../utils/isSlash.mjs';
 import isStandardSyntaxColorFunction from '../../utils/isStandardSyntaxColorFunction.mjs';
+import { isValueFunction } from '../../utils/typeGuards.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -142,21 +144,13 @@ function containsVariable(nodes) {
 	return nodes.some((node) => isVarFunction(node));
 }
 
-/**
- * @param {import('postcss-value-parser').Node} node
- * @returns {node is import('postcss-value-parser').DivNode}
- */
-function isComma(node) {
-	return isValueDiv(node) && node.value === ',';
-}
-
 /** @param {import('postcss-value-parser').Node[]} nodes */
 function isLikelyLegacy(nodes) {
 	let commas = 0;
 
 	for (const node of nodes) {
 		if (isComma(node)) commas++;
-		else if (node.value === '/') return false;
+		else if (isSlash(node)) return false;
 	}
 
 	return commas && (commas === 2 || commas === 3);

--- a/lib/rules/container-name-pattern/index.mjs
+++ b/lib/rules/container-name-pattern/index.mjs
@@ -3,11 +3,12 @@ import valueParser from 'postcss-value-parser';
 import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import { atRuleRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
-import { isValueDiv, isValueWord } from '../../utils/typeGuards.mjs';
 import { basicKeywords } from '../../reference/keywords.mjs';
+import isSlash from '../../utils/isSlash.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
+import { isValueWord } from '../../utils/typeGuards.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -53,7 +54,7 @@ const rule = (primary) => {
 
 				if (isContainerType) return;
 
-				if (isValueDiv(node) && value === '/') isContainerType = true;
+				if (isSlash(node)) isContainerType = true;
 
 				if (!isValueWord(node)) return false;
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -4,7 +4,7 @@ import { assert, isRegExp, isString } from '../../utils/validateTypes.mjs';
 import arrayEqual from '../../utils/arrayEqual.mjs';
 import { basicKeywords } from '../../reference/keywords.mjs';
 import eachDeclarationBlock from '../../utils/eachDeclarationBlock.mjs';
-import { isValueDiv } from '../../utils/typeGuards.mjs';
+import isComma from '../../utils/isComma.mjs';
 import { longhandSubPropertiesOfShorthandProperties } from '../../reference/properties.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -353,7 +353,7 @@ function commaSeparated(input) {
 	parts.push(current);
 
 	for (const node of valueParser(trimmed).nodes) {
-		if (isValueDiv(node) && node.value === ',') {
+		if (isComma(node)) {
 			current = [];
 			parts.push(current);
 		} else {

--- a/lib/rules/declaration-property-unit-allowed-list/index.mjs
+++ b/lib/rules/declaration-property-unit-allowed-list/index.mjs
@@ -4,6 +4,7 @@ import { isValueFunction, isValueString } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDimension from '../../utils/getDimension.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
+import isUrlFunction from '../../utils/isUrlFunction.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -66,14 +67,15 @@ const rule = (primary, secondaryOptions) => {
 
 			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
-				if (isValueFunction(node)) {
-					if (node.value.toLowerCase() === 'url') {
-						return false;
-					}
+				if (isUrlFunction(node)) {
+					return false;
+				}
 
-					if (optionsMatches(secondaryOptions, 'ignore', 'inside-function')) {
-						return false;
-					}
+				if (
+					isValueFunction(node) &&
+					optionsMatches(secondaryOptions, 'ignore', 'inside-function')
+				) {
+					return false;
 				}
 
 				if (isValueString(node)) {

--- a/lib/rules/font-family-no-duplicate-names/index.mjs
+++ b/lib/rules/font-family-no-duplicate-names/index.mjs
@@ -1,7 +1,7 @@
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import findFontFamily from '../../utils/findFontFamily.mjs';
-import { fontFamilyKeywords } from '../../reference/keywords.mjs';
+import isFamilyNameKeyword from '../../utils/isFamilyNameKeyword.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import { propertyRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
@@ -17,12 +17,6 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/font-family-no-duplicate-names',
 };
-
-/**
- * @param {import('postcss-value-parser').Node} node
- */
-const isFamilyNameKeyword = (node) =>
-	!('quote' in node) && fontFamilyKeywords.has(node.value.toLowerCase());
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -1,16 +1,17 @@
 import postcss from 'postcss';
 
 import { assert, isRegExp, isString } from '../../utils/validateTypes.mjs';
-import { fontFamilyKeywords, systemFontKeywords } from '../../reference/keywords.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import findFontFamily from '../../utils/findFontFamily.mjs';
 import { isAtRule } from '../../utils/typeGuards.mjs';
+import isFamilyNameKeyword from '../../utils/isFamilyNameKeyword.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
 import isVariable from '../../utils/isVariable.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import { propertyRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
+import { systemFontKeywords } from '../../reference/keywords.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 
 const ruleName = 'font-family-no-missing-generic-family-keyword';
@@ -22,13 +23,6 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/font-family-no-missing-generic-family-keyword',
 };
-
-/**
- * @param {import('postcss-value-parser').Node} node
- * @returns {boolean}
- */
-const isFamilyNameKeyword = (node) =>
-	!('quote' in node) && fontFamilyKeywords.has(node.value.toLowerCase());
 
 /**
  * @param {string} value

--- a/lib/rules/length-zero-no-unit/index.mjs
+++ b/lib/rules/length-zero-no-unit/index.mjs
@@ -2,11 +2,12 @@ import valueParser from 'postcss-value-parser';
 
 import { atRuleParamIndex, declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
-import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
 import isMathFunction from '../../utils/isMathFunction.mjs';
+import isSlash from '../../utils/isSlash.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
 import { lengthUnits } from '../../reference/units.mjs';
@@ -168,7 +169,7 @@ const rule = (primary, secondaryOptions) => {
 function isLineHeightValue({ prop }, nodes, index) {
 	const lastNode = nodes[index - 1];
 
-	return prop.toLowerCase() === 'font' && isValueDiv(lastNode) && lastNode.value === '/';
+	return prop.toLowerCase() === 'font' && isSlash(lastNode);
 }
 
 /**

--- a/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
@@ -1,9 +1,10 @@
 import { parse, walk } from 'css-tree';
 
 import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
-import { isAtRule, isRoot, isRule } from '../../utils/typeGuards.mjs';
+import { isAtRule, isRule } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
+import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import isInDocument from '../../utils/isInDocument.mjs';
@@ -124,33 +125,15 @@ const rule = (primary, secondaryOptions) => {
  * @returns {boolean}
  */
 function hasValidScopingRoot(node, secondaryOptions) {
-	let current = node.parent;
-
-	while (current) {
-		// If we find a rule in the parent chain, it provides a scoping root
-		if (isRule(current)) {
-			return true;
-		}
-
-		// If we find an @scope at-rule, it provides a scoping root
-		if (isAtRule(current) && current.name === 'scope') {
-			return true;
-		}
-
-		// If we find an ignored at-rule, it provides a scoping root
-		if (isAtRule(current) && optionsMatches(secondaryOptions, 'ignoreAtRules', current.name)) {
-			return true;
-		}
-
-		// If we reach the root without finding a scoping root
-		if (isRoot(current)) {
-			return false;
-		}
-
-		current = current.parent;
-	}
-
-	return false;
+	return Boolean(
+		findNodeUpToRoot(
+			node,
+			(current) =>
+				isRule(current) ||
+				(isAtRule(current) && current.name === 'scope') ||
+				(isAtRule(current) && optionsMatches(secondaryOptions, 'ignoreAtRules', current.name)),
+		),
+	);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/no-duplicate-at-import-rules/index.mjs
+++ b/lib/rules/no-duplicate-at-import-rules/index.mjs
@@ -2,13 +2,13 @@ import valueParser from 'postcss-value-parser';
 
 import {
 	isValueComment,
-	isValueDiv,
 	isValueFunction,
 	isValueSpace,
 	isValueWord,
 } from '../../utils/typeGuards.mjs';
 import { atRuleRegexes } from '../../utils/regexes.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
+import isComma from '../../utils/isComma.mjs';
 import isUrlFunction from '../../utils/isUrlFunction.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -127,7 +127,7 @@ function listImportConditions(params) {
 			}
 		}
 
-		if (isValueDiv(param) && param.value === ',') {
+		if (isComma(param)) {
 			media.push(stringifyCondition(lastMediaQuery));
 			lastMediaQuery = [];
 			continue;

--- a/lib/rules/relative-selector-nesting-notation/index.mjs
+++ b/lib/rules/relative-selector-nesting-notation/index.mjs
@@ -1,5 +1,6 @@
 import selectorParser from 'postcss-selector-parser';
 
+import containsNestingSelector from '../../utils/containsNestingSelector.mjs';
 import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import { isRule } from '../../utils/typeGuards.mjs';
@@ -87,24 +88,6 @@ const rule = (primary) => {
  */
 function isNestedStyleRule(ruleNode) {
 	return Boolean(findNodeUpToRoot(ruleNode, (node) => isRule(node)));
-}
-
-/**
- * Check if a selector contains the nesting selector
- *
- * @param {import('postcss-selector-parser').Selector} selector
- * @returns {boolean}
- */
-function containsNestingSelector(selector) {
-	let hasNestingSelector = false;
-
-	selector.walkNesting(() => {
-		hasNestingSelector = true;
-
-		return false;
-	});
-
-	return hasNestingSelector;
 }
 
 /**

--- a/lib/rules/rule-nesting-at-rule-required-list/index.mjs
+++ b/lib/rules/rule-nesting-at-rule-required-list/index.mjs
@@ -1,5 +1,6 @@
-import { isAtRule, isRoot } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
+import { isAtRule } from '../../utils/typeGuards.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import report from '../../utils/report.mjs';
@@ -59,23 +60,12 @@ const rule = (primary) => {
  * @returns {boolean} True if rule has required at-rule ancestor, false otherwise
  */
 function hasRequiredAtRuleAncestor(ruleNode, requiredAtRules) {
-	let current = ruleNode.parent;
-
-	while (current) {
-		// Check if current node is an at-rule (e.g., @layer, @scope, @supports)
-		if (isAtRule(current)) {
-			const atRuleName = current.name;
-
-			// Check if at-rule name matches any of the required patterns
-			if (matchesStringOrRegExp(atRuleName, requiredAtRules)) return true;
-		}
-
-		if (isRoot(current)) break;
-
-		current = current.parent;
-	}
-
-	return false;
+	return Boolean(
+		findNodeUpToRoot(
+			ruleNode,
+			(node) => isAtRule(node) && Boolean(matchesStringOrRegExp(node.name, requiredAtRules)),
+		),
+	);
 }
 
 rule.primaryOptionArray = true;

--- a/lib/rules/selector-combinator-allowed-list/index.mjs
+++ b/lib/rules/selector-combinator-allowed-list/index.mjs
@@ -2,6 +2,7 @@ import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import isStandardSyntaxCombinator from '../../utils/isStandardSyntaxCombinator.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
+import normalizeCombinator from '../../utils/normalizeCombinator.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -64,14 +65,6 @@ const rule = (primary) => {
 		});
 	};
 };
-
-/**
- * @param {string} value
- * @returns {string}
- */
-function normalizeCombinator(value) {
-	return value.replace(/\s+/g, ' ');
-}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-combinator-disallowed-list/index.mjs
+++ b/lib/rules/selector-combinator-disallowed-list/index.mjs
@@ -2,6 +2,7 @@ import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import isStandardSyntaxCombinator from '../../utils/isStandardSyntaxCombinator.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
+import normalizeCombinator from '../../utils/normalizeCombinator.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -64,14 +65,6 @@ const rule = (primary) => {
 		});
 	};
 };
-
-/**
- * @param {string} value
- * @returns {string}
- */
-function normalizeCombinator(value) {
-	return value.replace(/\s+/g, ' ');
-}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -3,6 +3,8 @@ import parser from 'postcss-selector-parser';
 import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
 import { isAtRule, isRule } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import containsNestingSelector from '../../utils/containsNestingSelector.mjs';
+import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
 import isCustomElement from '../../utils/isCustomElement.mjs';
@@ -28,7 +30,7 @@ const meta = {
 };
 
 /** @import { Rule } from 'postcss' */
-/** @import { Container as SelectorContainer, Node as SelectorNode } from 'postcss-selector-parser' */
+/** @import { Node as SelectorNode } from 'postcss-selector-parser' */
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
@@ -158,7 +160,7 @@ function hasImplicitDescendantCombinator(node, ruleNode) {
 
 	if (!isNestedRule(ruleNode)) return false;
 
-	return !isNestContaining(selector);
+	return !containsNestingSelector(selector);
 }
 
 /**
@@ -166,34 +168,12 @@ function hasImplicitDescendantCombinator(node, ruleNode) {
  * @returns {boolean}
  */
 function isNestedRule(ruleNode) {
-	/** @type {import('postcss').Container['parent']} */
-	let parentNode = ruleNode.parent;
-
-	while (parentNode) {
-		if (isRule(parentNode)) return true;
-
-		if (isAtRule(parentNode) && atRuleRegexes.scopeName.test(parentNode.name)) return true;
-
-		parentNode = parentNode.parent;
-	}
-
-	return false;
-}
-
-/**
- * @param {SelectorContainer} selector
- * @returns {boolean}
- */
-function isNestContaining(selector) {
-	let hasNesting = false;
-
-	selector.walkNesting(() => {
-		hasNesting = true;
-
-		return false;
-	});
-
-	return hasNesting;
+	return Boolean(
+		findNodeUpToRoot(
+			ruleNode,
+			(node) => isRule(node) || (isAtRule(node) && atRuleRegexes.scopeName.test(node.name)),
+		),
+	);
 }
 
 /**

--- a/lib/utils/__tests__/containsNestingSelector.test.mjs
+++ b/lib/utils/__tests__/containsNestingSelector.test.mjs
@@ -1,0 +1,22 @@
+import containsNestingSelector from '../containsNestingSelector.mjs';
+import selectorParser from 'postcss-selector-parser';
+
+describe('containsNestingSelector', () => {
+	it('is true when the selector contains a nesting selector', () => {
+		const root = selectorParser().astSync('& a');
+
+		expect(containsNestingSelector(root.first)).toBe(true);
+	});
+
+	it('is true for a nested nesting selector', () => {
+		const root = selectorParser().astSync('a > &');
+
+		expect(containsNestingSelector(root.first)).toBe(true);
+	});
+
+	it('is false when the selector has no nesting selector', () => {
+		const root = selectorParser().astSync('a b');
+
+		expect(containsNestingSelector(root.first)).toBe(false);
+	});
+});

--- a/lib/utils/__tests__/isComma.test.mjs
+++ b/lib/utils/__tests__/isComma.test.mjs
@@ -1,0 +1,16 @@
+import isComma from '../isComma.mjs';
+import valueParser from 'postcss-value-parser';
+
+describe('isComma', () => {
+	it('matches a comma div node', () => {
+		expect(isComma(valueParser('a, b').nodes[1])).toBe(true);
+	});
+
+	it('ignores other div nodes', () => {
+		expect(isComma(valueParser('a / b').nodes[1])).toBe(false);
+	});
+
+	it('ignores non-div nodes', () => {
+		expect(isComma(valueParser('a').nodes[0])).toBe(false);
+	});
+});

--- a/lib/utils/__tests__/isFamilyNameKeyword.test.mjs
+++ b/lib/utils/__tests__/isFamilyNameKeyword.test.mjs
@@ -1,0 +1,18 @@
+import isFamilyNameKeyword from '../isFamilyNameKeyword.mjs';
+import valueParser from 'postcss-value-parser';
+
+describe('isFamilyNameKeyword', () => {
+	it('matches generic font-family keywords', () => {
+		expect(isFamilyNameKeyword(valueParser('serif').nodes[0])).toBe(true);
+		expect(isFamilyNameKeyword(valueParser('SANS-SERIF').nodes[0])).toBe(true);
+		expect(isFamilyNameKeyword(valueParser('monospace').nodes[0])).toBe(true);
+	});
+
+	it('ignores quoted strings', () => {
+		expect(isFamilyNameKeyword(valueParser('"serif"').nodes[0])).toBe(false);
+	});
+
+	it('ignores non-keyword family names', () => {
+		expect(isFamilyNameKeyword(valueParser('Arial').nodes[0])).toBe(false);
+	});
+});

--- a/lib/utils/__tests__/isSlash.test.mjs
+++ b/lib/utils/__tests__/isSlash.test.mjs
@@ -1,0 +1,16 @@
+import isSlash from '../isSlash.mjs';
+import valueParser from 'postcss-value-parser';
+
+describe('isSlash', () => {
+	it('matches a slash div node', () => {
+		expect(isSlash(valueParser('a / b').nodes[1])).toBe(true);
+	});
+
+	it('ignores other div nodes', () => {
+		expect(isSlash(valueParser('a, b').nodes[1])).toBe(false);
+	});
+
+	it('ignores non-div nodes', () => {
+		expect(isSlash(valueParser('a').nodes[0])).toBe(false);
+	});
+});

--- a/lib/utils/__tests__/normalizeCombinator.test.mjs
+++ b/lib/utils/__tests__/normalizeCombinator.test.mjs
@@ -1,0 +1,15 @@
+import normalizeCombinator from '../normalizeCombinator.mjs';
+
+describe('normalizeCombinator', () => {
+	it('collapses whitespace runs to a single space', () => {
+		expect(normalizeCombinator('   ')).toBe(' ');
+		expect(normalizeCombinator('\n\t ')).toBe(' ');
+		expect(normalizeCombinator('>\n')).toBe('> ');
+	});
+
+	it('leaves single-character combinators unchanged', () => {
+		expect(normalizeCombinator('>')).toBe('>');
+		expect(normalizeCombinator('+')).toBe('+');
+		expect(normalizeCombinator('~')).toBe('~');
+	});
+});

--- a/lib/utils/containsNestingSelector.mjs
+++ b/lib/utils/containsNestingSelector.mjs
@@ -1,0 +1,17 @@
+/**
+ * Whether a selector contains a nesting selector.
+ *
+ * @param {import('postcss-selector-parser').Selector} selector
+ * @returns {boolean}
+ */
+export default function containsNestingSelector(selector) {
+	let found = false;
+
+	selector.walkNesting(() => {
+		found = true;
+
+		return false;
+	});
+
+	return found;
+}

--- a/lib/utils/findFontFamily.mjs
+++ b/lib/utils/findFontFamily.mjs
@@ -8,6 +8,7 @@ import {
 } from '../reference/keywords.mjs';
 import { isValueDiv, isValueFunction, isValueSpace } from './typeGuards.mjs';
 import { assert } from './validateTypes.mjs';
+import isComma from './isComma.mjs';
 import isNumbery from './isNumbery.mjs';
 import isStandardSyntaxValue from './isStandardSyntaxValue.mjs';
 import isValidFontSize from './isValidFontSize.mjs';
@@ -28,12 +29,6 @@ function joinValueNodes(firstNode, secondNode, charactersBetween) {
 
 	return firstNode;
 }
-
-/**
- * @param {Node} valueNode
- * @returns {valueNode is postcssValueParser.DivNode & { value: ',' }}
- */
-const isCommaDiv = (valueNode) => isValueDiv(valueNode) && valueNode.value === ',';
 
 /**
  * Get the font-families within a `font` shorthand property value.
@@ -102,7 +97,7 @@ export default function findFontFamily(value) {
 		if (
 			isFontFamilyKeyword &&
 			fontSizeKeywords.has(valueLowerCase) &&
-			!(!nextNode || isCommaDiv(nextNode) || allPrevNodes.find(isCommaDiv))
+			!(!nextNode || isComma(nextNode) || allPrevNodes.find(isComma))
 		)
 			return;
 

--- a/lib/utils/isComma.mjs
+++ b/lib/utils/isComma.mjs
@@ -1,9 +1,11 @@
 import { isValueDiv } from './typeGuards.mjs';
 
+/** @import { Maybe } from 'stylelint' */
+
 /**
  * Whether a node is a comma divider.
  *
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<import('postcss-value-parser').Node>} node
  * @returns {node is import('postcss-value-parser').DivNode}
  */
 export default function isComma(node) {

--- a/lib/utils/isComma.mjs
+++ b/lib/utils/isComma.mjs
@@ -1,0 +1,11 @@
+import { isValueDiv } from './typeGuards.mjs';
+
+/**
+ * Whether a node is a comma divider.
+ *
+ * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @returns {node is import('postcss-value-parser').DivNode}
+ */
+export default function isComma(node) {
+	return isValueDiv(node) && node.value === ',';
+}

--- a/lib/utils/isFamilyNameKeyword.mjs
+++ b/lib/utils/isFamilyNameKeyword.mjs
@@ -7,5 +7,5 @@ import { fontFamilyKeywords } from '../reference/keywords.mjs';
  * @returns {boolean}
  */
 export default function isFamilyNameKeyword(node) {
-	return !('quote' in node) && fontFamilyKeywords.has(node.value.toLowerCase());
+	return !isValueString(node) && fontFamilyKeywords.has(node.value.toLowerCase());
 }

--- a/lib/utils/isFamilyNameKeyword.mjs
+++ b/lib/utils/isFamilyNameKeyword.mjs
@@ -1,0 +1,11 @@
+import { fontFamilyKeywords } from '../reference/keywords.mjs';
+
+/**
+ * Whether a node is an unquoted generic font-family keyword.
+ *
+ * @param {import('postcss-value-parser').Node} node
+ * @returns {boolean}
+ */
+export default function isFamilyNameKeyword(node) {
+	return !('quote' in node) && fontFamilyKeywords.has(node.value.toLowerCase());
+}

--- a/lib/utils/isFamilyNameKeyword.mjs
+++ b/lib/utils/isFamilyNameKeyword.mjs
@@ -1,10 +1,11 @@
 import { fontFamilyKeywords } from '../reference/keywords.mjs';
+import { isValueString } from './typeGuards.mjs';
 
 /**
  * Whether a node is an unquoted generic font-family keyword.
  *
  * @param {import('postcss-value-parser').Node} node
- * @returns {boolean}
+ * @returns {node is Exclude<import('postcss-value-parser').Node, import('postcss-value-parser').StringNode>}
  */
 export default function isFamilyNameKeyword(node) {
 	return !isValueString(node) && fontFamilyKeywords.has(node.value.toLowerCase());

--- a/lib/utils/isFamilyNameKeyword.mjs
+++ b/lib/utils/isFamilyNameKeyword.mjs
@@ -1,12 +1,14 @@
 import { fontFamilyKeywords } from '../reference/keywords.mjs';
-import { isValueString } from './typeGuards.mjs';
+import { isValueWord } from './typeGuards.mjs';
+
+/** @import { Maybe } from 'stylelint' */
 
 /**
  * Whether a node is an unquoted generic font-family keyword.
  *
- * @param {import('postcss-value-parser').Node} node
- * @returns {node is Exclude<import('postcss-value-parser').Node, import('postcss-value-parser').StringNode>}
+ * @param {Maybe<import('postcss-value-parser').Node>} node
+ * @returns {node is import('postcss-value-parser').WordNode}
  */
 export default function isFamilyNameKeyword(node) {
-	return !isValueString(node) && fontFamilyKeywords.has(node.value.toLowerCase());
+	return isValueWord(node) && fontFamilyKeywords.has(node.value.toLowerCase());
 }

--- a/lib/utils/isSlash.mjs
+++ b/lib/utils/isSlash.mjs
@@ -1,9 +1,11 @@
 import { isValueDiv } from './typeGuards.mjs';
 
+/** @import { Maybe } from 'stylelint' */
+
 /**
  * Whether a node is a slash divider.
  *
- * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @param {Maybe<import('postcss-value-parser').Node>} node
  * @returns {node is import('postcss-value-parser').DivNode}
  */
 export default function isSlash(node) {

--- a/lib/utils/isSlash.mjs
+++ b/lib/utils/isSlash.mjs
@@ -1,0 +1,11 @@
+import { isValueDiv } from './typeGuards.mjs';
+
+/**
+ * Whether a node is a slash divider.
+ *
+ * @param {import('postcss-value-parser').Node | null | undefined} node
+ * @returns {node is import('postcss-value-parser').DivNode}
+ */
+export default function isSlash(node) {
+	return isValueDiv(node) && node.value === '/';
+}

--- a/lib/utils/normalizeCombinator.mjs
+++ b/lib/utils/normalizeCombinator.mjs
@@ -1,0 +1,9 @@
+/**
+ * Normalize a combinator's whitespace to a single space.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export default function normalizeCombinator(value) {
+	return value.replace(/\s+/g, ' ');
+}

--- a/lib/utils/typeGuards.mjs
+++ b/lib/utils/typeGuards.mjs
@@ -1,10 +1,6 @@
 /** @import { Node as PostcssNode } from 'postcss' */
 /** @import { Node as ValueNode } from 'postcss-value-parser' */
-
-/**
- * @template T
- * @typedef {T | null | undefined} Maybe
- */
+/** @import { Maybe } from 'stylelint' */
 
 /**
  * @param {Maybe<PostcssNode>} node

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1681,6 +1681,11 @@ declare namespace stylelint {
 			longhandSubPropertiesOfShorthandProperties: LonghandSubPropertiesOfShorthandProperties;
 		};
 	};
+
+	// Project-specific utility types
+
+	/** @internal */
+	export type Maybe<T> = T | null | undefined;
 }
 
 declare const stylelint: stylelint.PublicApi & {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/9319#discussion_r3330080685

> Is there anything in the PR that needs further explanation?

It moves a handful of duplicated inline helpers to shared utilities:

- `isComma` & `isSlash`
- `isFamilyNameKeyword`
- `containsNestingSelector`
- `normalizeCombinator`

And reuses a couple of shared utilities:

- `isUrlFunction`
- `findNodeUpToRoot`

I've kept it focused on the low-hanging fruit and limited in scope to make it easier to review.
