### PR TITLE
Refactor to replace `benchmark` with `tinybench`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
         "@types/svg-tags": "^1.0.2",
         "@types/write-file-atomic": "^4.0.3",
         "@vscode/windows-process-tree": "^0.7.0",
-        "benchmark": "^2.1.4",
         "common-tags": "^1.8.2",
         "deepmerge": "^4.3.1",
         "eslint": "^10.4.0",
@@ -97,6 +96,7 @@
         "prettier": "^3.8.3",
         "remark-cli": "^12.0.1",
         "sugarss": "^5.0.1",
+        "tinybench": "^6.0.2",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -4050,16 +4050,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
       }
     },
     "node_modules/better-path-resolve": {
@@ -9737,13 +9727,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -11485,12 +11468,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -13665,6 +13642,16 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.0.2.tgz",
+      "integrity": "sha512-FlHoQpcFvCzeXK5kVPvV7IVgW/hs/B36QWTz876iSdeJguBDfdTSRQmYmaHX+fQNt4hp+gEFB2XXw+8hT4/y8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "@types/svg-tags": "^1.0.2",
     "@types/write-file-atomic": "^4.0.3",
     "@vscode/windows-process-tree": "^0.7.0",
-    "benchmark": "^2.1.4",
     "common-tags": "^1.8.2",
     "deepmerge": "^4.3.1",
     "eslint": "^10.4.0",
@@ -200,6 +199,7 @@
     "prettier": "^3.8.3",
     "remark-cli": "^12.0.1",
     "sugarss": "^5.0.1",
+    "tinybench": "^6.0.2",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/scripts/benchmarking/run-rule.mjs
+++ b/scripts/benchmarking/run-rule.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { argv, exit } from 'node:process';
 
-import Benchmark from 'benchmark';
+import { Bench } from 'tinybench';
 import picocolors from 'picocolors';
 
 import stylelint from '../../lib/index.mjs';
@@ -75,58 +75,31 @@ const lintConfig = {
 const lint = (code) => stylelint.lint({ code, config: lintConfig });
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins -- This script is only for development. We can tolerate it.
-Promise.all(CSS_URLs.map((url) => fetch(url).then((res) => res.text())))
-	.then((responses) => {
-		const source = responses.join('\n\n');
+const responses = await Promise.all(CSS_URLs.map((url) => fetch(url).then((res) => res.text())));
+const source = responses.join('\n\n');
+const css = `${source}\n\n`.repeat(DUPLICATE_SOURCE_N_TIMES);
 
-		let css = '';
+const { results } = await lint(css);
 
-		for (let i = 0; i < DUPLICATE_SOURCE_N_TIMES; i++) {
-			css += `${source}\n\n`;
-		}
+results.forEach(({ parseErrors, invalidOptionWarnings, warnings }) => {
+	parseErrors.forEach(({ text }) => {
+		console.error(bold(red(`>> ${text}`)));
+	});
+	invalidOptionWarnings.forEach(({ text }) => {
+		console.warn(bold(yellow(`>> ${text}`)));
+	});
+	console.log(`${bold('Warnings')}: ${warnings.length}`);
+});
 
-		let firstTime = true;
-		let lazyResult;
+const TASK_NAME = 'rule test';
+const bench = new Bench({ name: ruleName, throws: true });
 
-		const bench = new Benchmark('rule test', {
-			defer: true,
-			setup: () => {
-				lazyResult = lint(css);
-			},
-			onCycle: () => {
-				lazyResult = lint(css);
-			},
-			fn: (deferred) => {
-				lazyResult
-					.then((result) => {
-						if (firstTime) {
-							firstTime = false;
-							result.results.forEach(({ parseErrors, invalidOptionWarnings, warnings }) => {
-								parseErrors.forEach(({ text }) => {
-									console.error(bold(red(`>> ${text}`)));
-								});
-								invalidOptionWarnings.forEach(({ text }) => {
-									console.warn(bold(yellow(`>> ${text}`)));
-								});
-								console.log(`${bold('Warnings')}: ${warnings.length}`);
-							});
-						}
+bench.add(TASK_NAME, () => lint(css));
 
-						deferred.resolve();
-					})
-					.catch((err) => {
-						console.error(err.stack);
-						deferred.resolve();
-					});
-			},
-		});
+await bench.run();
 
-		bench.on('complete', () => {
-			console.log(`${bold('Mean')}: ${bench.stats.mean * 1000} ms`);
-			console.log(`${bold('Deviation')}: ${bench.stats.deviation * 1000} ms`);
-		});
+const { mean, sd } = bench.getTask(TASK_NAME).result.latency;
 
-		bench.run();
-	})
-	.catch((error) => console.error('error:', error));
+console.log(`${bold('Mean')}: ${mean} ms`);
+console.log(`${bold('Deviation')}: ${sd} ms`);
 /* eslint-enable no-console */

--- a/scripts/benchmarking/run-rule.mjs
+++ b/scripts/benchmarking/run-rule.mjs
@@ -79,20 +79,26 @@ const responses = await Promise.all(CSS_URLs.map((url) => fetch(url).then((res) 
 const source = responses.join('\n\n');
 const css = `${source}\n\n`.repeat(DUPLICATE_SOURCE_N_TIMES);
 
-const { results } = await lint(css);
-
-results.forEach(({ parseErrors, invalidOptionWarnings, warnings }) => {
-	parseErrors.forEach(({ text }) => {
-		console.error(bold(red(`>> ${text}`)));
-	});
-	invalidOptionWarnings.forEach(({ text }) => {
-		console.warn(bold(yellow(`>> ${text}`)));
-	});
-	console.log(`${bold('Warnings')}: ${warnings.length}`);
-});
-
 const TASK_NAME = 'rule test';
-const bench = new Bench({ name: ruleName, throws: true });
+const bench = new Bench({
+	name: ruleName,
+	throws: true,
+	setup: async (_task, mode) => {
+		if (mode !== 'run') return;
+
+		const { results } = await lint(css);
+
+		results.forEach(({ parseErrors, invalidOptionWarnings, warnings }) => {
+			parseErrors.forEach(({ text }) => {
+				console.error(bold(red(`>> ${text}`)));
+			});
+			invalidOptionWarnings.forEach(({ text }) => {
+				console.warn(bold(yellow(`>> ${text}`)));
+			});
+			console.log(`${bold('Warnings')}: ${warnings.length}`);
+		});
+	},
+});
 
 bench.add(TASK_NAME, () => lint(css));
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it's a refactor.

> Is there anything in the PR that needs further explanation?

As part of the Stylelint 18 preparation, we intend to modernise our user-facing dependencies:
- https://github.com/stylelint/stylelint/issues/9338

We don't need to be as concerned about accidentally breaking things with dev dependencies, so we can update these outside of the major release to keep the ball rolling after starting it in the [create-stylelint](https://github.com/stylelint/create-stylelint/pulls) repo.

This PR switches `benchmark` to `tinybench`, which is part of the [tinylibs org](https://github.com/tinylibs) and coming from the [e18e community](https://e18e.dev/).

Here's a [comparison](https://npmx.dev/compare?packages=tinybench,benchmark) of the packages, notably reducing the install size from 1.5MB to 78kB and with no transitive dependencies.

Manually tested:

```
# Clean

jeddy3@mac stylelint % npm run benchmark-rule color-no-hex true

> stylelint@17.13.0 benchmark-rule
> node scripts/benchmarking/run-rule.mjs color-no-hex true

Warnings: 2165
Mean: 74.41328570312493 ms
Deviation: 7.2991989485000985 ms

# With invalid option

jeddy3@mac stylelint % npm run benchmark-rule color-no-hex tru 

> stylelint@17.13.0 benchmark-rule
> node scripts/benchmarking/run-rule.mjs color-no-hex tru

>> Unexpected option value "tru" for rule "color-no-hex"
Warnings: 0
Mean: 75.03815039062495 ms
Deviation: 6.357986436221377 ms
```
