### PR TITLE
Bump codecov/codecov-action from 6.0.1 to 7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./.coverage/lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Blocks #9343

> Is there anything in the PR that needs further explanation?

Fixes the CI failure by bumping the Codecov action:

```
Could not verify signature. Please contact Codecov if problem continues
```

Ref:
-  https://github.com/stylelint/stylelint/actions/runs/27127841736/job/80082814458?pr=9343#step:7:254
- https://github.com/codecov/codecov-action/releases/tag/v7.0.0
- https://github.com/codecov/codecov-action/compare/v6.0.1...v7.0.0


