### PR TITLE
Fix performance by dynamically importing `TIMING` only on use

### DIFF
--- a/.changeset/common-shirts-read.md
+++ b/.changeset/common-shirts-read.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: performance of loading `table` dependency
+Fixed: performance by dynamically importing `TIMING` only on use

--- a/.changeset/common-shirts-read.md
+++ b/.changeset/common-shirts-read.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: performance of loading `table` dependency

--- a/lib/lintPostcssResult.mjs
+++ b/lib/lintPostcssResult.mjs
@@ -1,4 +1,5 @@
 import { EOL } from 'node:os';
+import process from 'node:process';
 
 import { DEFAULT_SEVERITY, RULE_NAME_ALL } from './constants.mjs';
 import { DEFAULT_CONFIGURATION_COMMENT } from './utils/configurationComment.mjs';
@@ -7,7 +8,6 @@ import { emitDeprecationWarning } from './utils/emitWarning.mjs';
 import getStylelintRule from './utils/getStylelintRule.mjs';
 import reportUnknownRuleNames from './reportUnknownRuleNames.mjs';
 import rules from './rules/index.mjs';
-import timing from './timing.mjs';
 
 /** @import {Config, LinterOptions, PostcssResult} from 'stylelint' */
 
@@ -72,6 +72,8 @@ export default async function lintPostcssResult(stylelintOptions, postcssResult,
 		}),
 	);
 
+	const timing = process.env.TIMING ? (await import('./timing.mjs')).default : undefined;
+
 	for (const [ruleName, ruleFunction] of ruleEntries) {
 		if (ruleFunction === undefined) {
 			performRules.push(
@@ -131,7 +133,7 @@ export default async function lintPostcssResult(stylelintOptions, postcssResult,
 		 * @param {import('postcss').Root} postcssRoot
 		 */
 		async function runRule(postcssRoot) {
-			if (timing.enabled) {
+			if (timing?.enabled) {
 				return timing.time(ruleName, () => ruleFn(postcssRoot, postcssResult))();
 			}
 

--- a/lib/timing.mjs
+++ b/lib/timing.mjs
@@ -1,7 +1,5 @@
-import { createRequire } from 'node:module';
 import process from 'node:process';
-
-const require = createRequire(import.meta.url);
+import { table } from 'table';
 
 // Inspired by ESLint's timing.js
 // https://github.com/eslint/eslint/blob/09bc2a88c00aa9a93c7de505795fc4e85b2e6357/lib/linter/timing.js
@@ -71,8 +69,6 @@ const tableConfig = {
  * @private
  */
 function display(data) {
-	const { table } = /** @type {typeof import('table')} */ (require('table'));
-
 	let total = 0;
 
 	/** @type {Array<[string, number]>} */

--- a/lib/timing.mjs
+++ b/lib/timing.mjs
@@ -1,5 +1,6 @@
 import process from 'node:process';
-import { table } from 'table';
+
+import { assert } from './utils/validateTypes.mjs';
 
 // Inspired by ESLint's timing.js
 // https://github.com/eslint/eslint/blob/09bc2a88c00aa9a93c7de505795fc4e85b2e6357/lib/linter/timing.js
@@ -52,6 +53,8 @@ function getListSize() {
 const listSize = getListSize();
 const enabled = listSize !== 0;
 
+const table = enabled ? (await import('table')).table : undefined;
+
 /** @type {import('table').TableUserConfig}  */
 const tableConfig = {
 	columns: [
@@ -69,6 +72,8 @@ const tableConfig = {
  * @private
  */
 function display(data) {
+	assert(table, 'table module loaded');
+
 	let total = 0;
 
 	/** @type {Array<[string, number]>} */

--- a/lib/timing.mjs
+++ b/lib/timing.mjs
@@ -1,6 +1,7 @@
+import { createRequire } from 'node:module';
 import process from 'node:process';
 
-import { assert } from './utils/validateTypes.mjs';
+const require = createRequire(import.meta.url);
 
 // Inspired by ESLint's timing.js
 // https://github.com/eslint/eslint/blob/09bc2a88c00aa9a93c7de505795fc4e85b2e6357/lib/linter/timing.js
@@ -53,8 +54,6 @@ function getListSize() {
 const listSize = getListSize();
 const enabled = listSize !== 0;
 
-const table = enabled ? (await import('table')).table : undefined;
-
 /** @type {import('table').TableUserConfig}  */
 const tableConfig = {
 	columns: [
@@ -72,7 +71,7 @@ const tableConfig = {
  * @private
  */
 function display(data) {
-	assert(table, 'table module loaded');
+	const { table } = /** @type {typeof import('table')} */ (require('table'));
 
 	let total = 0;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, performance improvement.

> Is there anything in the PR that needs further explanation?

We plan to replace `table` in Stylelint 18, but in the meantime, this fix avoids it being eagerly loaded on every run regardless of if `TIMING` is used:

https://github.com/stylelint/stylelint/blob/09ebc3501310daaf0cd8611ab3fca239523e5386/lib/lintPostcssResult.mjs#L10

The other instance of `table` appears in the `string` formatter, which is loaded lazily.

It shaves a few ms off the benchmarks:

```
════════════════════════════════════════════════════════════════════════════════
  PERFORMANCE COMPARISON
════════════════════════════════════════════════════════════════════════════════

  Size      Baseline    Current     Diff        Change    Status    
  ────────────────────────────────────────────────────────────────────────────
  Small     175.69ms    171.43ms    4.26ms      -2.4%     ≈ Same    
  Medium    235.84ms    229.31ms    6.54ms      -2.8%     ≈ Same    
  Large     601.42ms    594.39ms    7.03ms      -1.2%     ≈ Same    
  X-Large   1.22s       1.16s       53.68ms     -4.4%     ≈ Same    
  ────────────────────────────────────────────────────────────────────────────

════════════════════════════════════════════════════════════════════════════════
```
