### PR TITLE
Fix `function-calc-no-unspaced-operator` false negatives for unspaced operators after multiplication or division

### DIFF
--- a/.changeset/calm-pillows-fix.md
+++ b/.changeset/calm-pillows-fix.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `function-calc-no-unspaced-operator` false negatives for unspaced `+` and `-` operators following a `*` or `/` operator

--- a/lib/rules/function-calc-no-unspaced-operator/README.md
+++ b/lib/rules/function-calc-no-unspaced-operator/README.md
@@ -42,11 +42,6 @@ a { top: calc(1px+ 2px); }
 a { transform: rotate(atan(-2+1)); }
 ```
 
-<!-- prettier-ignore -->
-```css
-a { top: calc(1px*2px+3px); }
-```
-
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/function-calc-no-unspaced-operator/README.md
+++ b/lib/rules/function-calc-no-unspaced-operator/README.md
@@ -42,6 +42,11 @@ a { top: calc(1px+ 2px); }
 a { transform: rotate(atan(-2+1)); }
 ```
 
+<!-- prettier-ignore -->
+```css
+a { top: calc(1px*2px+3px); }
+```
+
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -314,20 +314,20 @@ testRule({
 			],
 		},
 		{
-			code: 'a { top: calc(1px/2+3px); }',
-			fixed: 'a { top: calc(1px/2 + 3px); }',
-			description: 'unspaced "+" after a division',
+			code: 'a { top: calc(1px/2-3px); }',
+			fixed: 'a { top: calc(1px/2 - 3px); }',
+			description: 'unspaced "-" after a division',
 			warnings: [
 				{
-					message: messages.expectedAfter('+'),
+					message: messages.expectedAfter('-'),
 					line: 1,
 					column: 20,
 					endLine: 1,
 					endColumn: 21,
-					fix: { range: [19, 20], text: '+ ' },
+					fix: { range: [19, 20], text: '- ' },
 				},
 				{
-					message: messages.expectedBefore('+'),
+					message: messages.expectedBefore('-'),
 					line: 1,
 					column: 20,
 					endLine: 1,

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -69,6 +69,14 @@ testRule({
 			code: 'a { top: calc(calc(1em * 2) / 3); }',
 		},
 		{
+			code: 'a { top: calc(1px*2*3); }',
+			description: 'chained multiplication without addition or subtraction',
+		},
+		{
+			code: 'a { top: calc(8px/2/2); }',
+			description: 'chained division without addition or subtraction',
+		},
+		{
 			code: 'a { padding: calc(1px + 2px) calc(1px + 2px); }',
 		},
 		{
@@ -278,6 +286,75 @@ testRule({
 					column: 18,
 					endLine: 1,
 					endColumn: 19,
+					fix: undefined,
+				},
+			],
+		},
+		{
+			code: 'a { top: calc(1px*2px+3px); }',
+			fixed: 'a { top: calc(1px*2px + 3px); }',
+			description: 'unspaced "+" after a multiplication',
+			warnings: [
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 23,
+					fix: { range: [21, 22], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 23,
+					fix: undefined,
+				},
+			],
+		},
+		{
+			code: 'a { top: calc(1px/2+3px); }',
+			fixed: 'a { top: calc(1px/2 + 3px); }',
+			description: 'unspaced "+" after a division',
+			warnings: [
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 21,
+					fix: { range: [19, 20], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 21,
+					fix: undefined,
+				},
+			],
+		},
+		{
+			code: 'a { top: calc(1px + 2px*3px+4px); }',
+			fixed: 'a { top: calc(1px + 2px*3px + 4px); }',
+			description: 'unspaced "+" after a multiplication that follows a spaced operator',
+			warnings: [
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 29,
+					fix: { range: [27, 28], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 29,
 					fix: undefined,
 				},
 			],

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -49,6 +49,7 @@ const meta = {
 };
 
 const OPERATORS = new Set(['+', '-']);
+const MULTIPLICATIVE_OPERATORS = new Set(['*', '/']);
 
 const FUNC_NAMES_REGEX = new RegExp(`^(?:${[...mathFunctions].join('|')})$`, 'i');
 
@@ -563,15 +564,24 @@ function parseOperation(container, cursor) {
 	}
 
 	// If we have not consumed any operands, we are not in an operation
-	// Do error recovery by consuming until the next comma or semicolon
-	// If no comma or semicolon is found, consume until the end of the container
+	// Do error recovery by consuming until the next boundary: a comma, a semicolon
+	// or a multiplicative operator (`*` or `/`)
+	// If no boundary is found, consume until the end of the container
 	if (!firstOperand || !secondOperand) {
 		while (currentNode) {
-			if (
-				isTokenNode(currentNode) &&
-				(isTokenComma(currentNode.value) || isTokenSemicolon(currentNode.value))
-			) {
-				return [undefined, cursor];
+			if (isTokenNode(currentNode)) {
+				if (isTokenComma(currentNode.value) || isTokenSemicolon(currentNode.value)) {
+					return [undefined, cursor];
+				}
+
+				// Multiplicative operators don't require surrounding whitespace, but the
+				// operation after them must still be checked for unspaced `+` or `-`.
+				if (
+					isTokenDelim(currentNode.value) &&
+					MULTIPLICATIVE_OPERATORS.has(currentNode.value[4].value)
+				) {
+					return [undefined, cursor];
+				}
 			}
 
 			currentNode = container.value[++cursor];


### PR DESCRIPTION
## Which issue, if any, is this issue related to?

None open. This is a distinct case from the already-fixed #7181 and #9220, both of which involved only `+`/`-` operators and are now correctly caught.

## Is there anything in the PR that needs further explanation?

### The problem

`function-calc-no-unspaced-operator` misses an unspaced `+` or `-` operator whenever a `*` or `/` operator appears earlier in the same math expression. The `+`/`-` is genuinely invalid CSS (the spec requires whitespace around `+` and `-`), but no warning is reported:

```css
a { width: calc(1px*2px+3px); } /* the `+` is missed */
a { width: calc(1px/2+3px); }   /* the `+` is missed */
a { width: calc(1px + 2px*3px+4px); } /* the second `+` is missed */
```

The same `+`/`-` is reported correctly when no `*`/`/` precedes it, e.g. `calc(3px+1px*2px)`.

### Root cause

The expression is parsed into operations, and parsing falls into error recovery when it cannot form a complete operation. For `1px*2px+3px` the parser consumes `1px`, then hits the `*` delimiter where it expects a `+`/`-` operator (or a second operand). Since `*`/`/` are not in the `+`/`-` operator set, no operation is formed and error recovery kicks in — but it consumes everything up to the next comma, semicolon, or the end of the expression. That swallows the trailing `2px+3px`, so the unspaced `+` is never examined.

### The fix

Error recovery now also treats a multiplicative operator (`*` or `/`) as a boundary and stops there, letting the parser resume scanning the operands that follow it. `*` and `/` legitimately don't require surrounding whitespace, so they're left untouched while the subsequent `+`/`-` operations are checked as usual. Autofix only inserts the missing spaces around `+`/`-` and leaves `*`/`/` alone (`calc(1px*2px+3px)` → `calc(1px*2px + 3px)`), and it's idempotent.

## Did you add or update tests?

Yes. Added reject cases for an unspaced `+`/`-` after `*`, after `/`, and after a `*` that itself follows a properly spaced operator, each asserting the warnings and the fixed output. Added accept cases for multiplication/division-only chains (`calc(1px*2*3)`, `calc(8px/2/2)`) as regression guards. The new reject cases fail on `main` and pass with the fix. Rule tests (135), ESLint, Prettier, and remark pass locally.

## Have you successfully run tests with your changes locally?

Yes.
