### PR TITLE
Valid disables reported when `--report-needless-disables`, `--quiet` and `defaultSeverity` in config are set

### DIFF
--- a/.changeset/quiet-disables-report.md
+++ b/.changeset/quiet-disables-report.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed valid warning-level disables being reported as needless when using `quiet`, `defaultSeverity`, and `reportNeedlessDisables`.

--- a/lib/__tests__/standalone-quiet.test.mjs
+++ b/lib/__tests__/standalone-quiet.test.mjs
@@ -33,6 +33,24 @@ it('standalone with input css and quiet mode (in option)', async () => {
 	expect(results[0].warnings).toEqual([]);
 });
 
+it('standalone with valid warning disable in quiet and reportNeedlessDisables mode', async () => {
+	const config = {
+		defaultSeverity: 'warning',
+		reportNeedlessDisables: true,
+		rules: {
+			'block-no-empty': true,
+		},
+	};
+
+	const { results } = await standalone({
+		code: '/* stylelint-disable-next-line block-no-empty */\na {}',
+		config,
+		quiet: true,
+	});
+
+	expect(results[0].warnings).toEqual([]);
+});
+
 it('standalone with custom rule using checkAgainstRule on quiet and reportNeedlessDisables mode', async () => {
 	const customRuleName = 'custom/rule';
 	const customRule = (primary, secondary, context) => {

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -49,9 +49,6 @@ export default function report(problem) {
 	const ruleSeverity =
 		(isFn(severity) ? severity(...messageArgs) : severity) ?? defaultSeverity ?? DEFAULT_SEVERITY;
 
-	// In quiet mode, mere warnings are ignored
-	if (quiet && ruleSeverity === SEVERITY_WARNING) return;
-
 	if ((isFn(fix) || isFixObject(fix)) && metadata && !metadata.fixable) {
 		throw new Error(
 			`The "${ruleName}" rule requires "meta.fixable" to be truthy if the "fix" callback is being passed`,
@@ -60,7 +57,9 @@ export default function report(problem) {
 
 	if (isFixApplied(problem, problemRange.start.line)) return;
 
-	if (isDisabledOnLine(ruleName, problemRange.start.line, disabledRanges)) {
+	const isDisabled = isDisabledOnLine(ruleName, problemRange.start.line, disabledRanges);
+
+	if (isDisabled) {
 		// Collect disabled warnings
 		// Used to report `needlessDisables` in subsequent processing.
 		const disabledWarnings = (result.stylelint.disabledWarnings ||= []);
@@ -72,6 +71,9 @@ export default function report(problem) {
 
 		if (!ignoreDisables) return;
 	}
+
+	// In quiet mode, mere warnings are ignored
+	if (quiet && ruleSeverity === SEVERITY_WARNING) return;
 
 	if (!result.stylelint.stylelintError && ruleSeverity === SEVERITY_ERROR) {
 		result.stylelint.stylelintError = true;


### PR DESCRIPTION
## Summary

- collect disabled warnings before applying `quiet` filtering
- add a regression test for valid warning-level disables with `defaultSeverity`, `quiet`, and `reportNeedlessDisables`
- add a patch changeset

Fixes #9375

## Testing

- `npm run test-only -- lib/__tests__/standalone-quiet.test.mjs --runInBand`
- `npm run test-only -- lib/__tests__/needlessDisables.test.mjs lib/__tests__/standalone-quiet.test.mjs --runInBand`
- `npx prettier --check lib/utils/report.mjs lib/__tests__/standalone-quiet.test.mjs .changeset/quiet-disables-report.md`
- `npx eslint lib/utils/report.mjs lib/__tests__/standalone-quiet.test.mjs --max-warnings=0`
- `git diff --check`
