### PR TITLE
Fix needless disables with quiet warnings

### DIFF
--- a/lib/__tests__/needlessDisables.test.mjs
+++ b/lib/__tests__/needlessDisables.test.mjs
@@ -408,6 +408,29 @@ it('needlessDisables severity', async () => {
 	expect(results[0].errored).toBe(false);
 });
 
+it('needlessDisables does not report useful disables as needless in quiet mode', async () => {
+	const config = {
+		defaultSeverity: 'warning',
+		rules: { 'block-no-empty': true },
+	};
+
+	const css = stripIndent`
+		/* stylelint-disable-next-line block-no-empty */
+		a {}
+		`;
+
+	const { results } = await standalone({
+		config,
+		code: css,
+		quiet: true,
+		reportNeedlessDisables: true,
+	});
+
+	expect(results).toHaveLength(1);
+	expect(results[0].warnings).toEqual([]);
+	expect(results[0].errored).toBe(false);
+});
+
 it('needlessDisables with configurationComment', async () => {
 	const config = {
 		rules: { 'block-no-empty': true },

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -49,9 +49,6 @@ export default function report(problem) {
 	const ruleSeverity =
 		(isFn(severity) ? severity(...messageArgs) : severity) ?? defaultSeverity ?? DEFAULT_SEVERITY;
 
-	// In quiet mode, mere warnings are ignored
-	if (quiet && ruleSeverity === SEVERITY_WARNING) return;
-
 	if ((isFn(fix) || isFixObject(fix)) && metadata && !metadata.fixable) {
 		throw new Error(
 			`The "${ruleName}" rule requires "meta.fixable" to be truthy if the "fix" callback is being passed`,
@@ -72,6 +69,9 @@ export default function report(problem) {
 
 		if (!ignoreDisables) return;
 	}
+
+	// In quiet mode, mere warnings are ignored
+	if (quiet && ruleSeverity === SEVERITY_WARNING) return;
 
 	if (!result.stylelint.stylelintError && ruleSeverity === SEVERITY_ERROR) {
 		result.stylelint.stylelintError = true;


### PR DESCRIPTION
﻿## Summary
- Collect disabled warnings before applying `quiet` filtering
- Prevent `--report-needless-disables` from treating valid warning-level disables as needless when `--quiet` is enabled
- Add regression coverage for `defaultSeverity: "warning"` with `quiet` and `reportNeedlessDisables`

Fixes #9375

## Tests
- npm.cmd run test-only -- lib/__tests__/needlessDisables.test.mjs lib/__tests__/standalone-quiet.test.mjs
- npm.cmd run lint:formatting
- npm.cmd run lint:js

`npm.cmd run lint:types` currently fails on unrelated existing type errors in `lib/rules/nesting-selector-no-missing-scoping-root/index.mjs`, `lib/rules/property-no-unknown/index.mjs`, and `lib/utils/getLexer.mjs`.
