### PR TITLE
Fix reported range of unknown rules

### DIFF
--- a/.changeset/silent-rice-read.md
+++ b/.changeset/silent-rice-read.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: reported range of unknown rules

--- a/lib/__tests__/reportUnknownRuleNames.test.mjs
+++ b/lib/__tests__/reportUnknownRuleNames.test.mjs
@@ -14,25 +14,26 @@ it('test case (1)', async () => {
 	});
 
 	expect(results).toHaveLength(1);
-	expect(results[0].warnings).toHaveLength(2);
-	expect(results[0].warnings).toContainEqual({
-		line: 1,
-		column: 1,
-		endLine: 1,
-		endColumn: 6,
-		severity: 'error',
-		rule: 'color-namd',
-		text: 'Unknown rule color-namd. Did you mean color-named?',
-	});
-	expect(results[0].warnings).toContainEqual({
-		line: 1,
-		column: 1,
-		endLine: 1,
-		endColumn: 6,
-		severity: 'error',
-		rule: 'function-allowed-lst',
-		text: 'Unknown rule function-allowed-lst. Did you mean function-allowed-list?',
-	});
+	expect(results[0].warnings).toMatchObject([
+		{
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 2,
+			severity: 'error',
+			rule: 'color-namd',
+			text: 'Unknown rule color-namd. Did you mean color-named?',
+		},
+		{
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 2,
+			severity: 'error',
+			rule: 'function-allowed-lst',
+			text: 'Unknown rule function-allowed-lst. Did you mean function-allowed-list?',
+		},
+	]);
 });
 
 it('test case (2)', async () => {
@@ -49,20 +50,20 @@ it('test case (2)', async () => {
 	});
 
 	expect(results).toHaveLength(1);
-	expect(results[0].warnings).toHaveLength(2);
-	expect(results[0].warnings).toContainEqual({
-		line: 1,
-		column: 1,
-		endLine: 1,
-		endColumn: 43,
-		severity: 'error',
-		rule: 'function-allowed-lst',
-		text: 'Unknown rule function-allowed-lst. Did you mean function-allowed-list?',
-	});
-	expect(results[0].warnings).toContainEqual(
+	expect(results[0].warnings).toMatchObject([
+		{
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 2,
+			severity: 'error',
+			rule: 'function-allowed-lst',
+			text: 'Unknown rule function-allowed-lst. Did you mean function-allowed-list?',
+		},
 		expect.objectContaining({
 			severity: 'error',
 			rule: 'color-named',
+			text: expect.stringMatching('#fff'),
 		}),
-	);
+	]);
 });

--- a/lib/reportUnknownRuleNames.mjs
+++ b/lib/reportUnknownRuleNames.mjs
@@ -72,5 +72,6 @@ export default function reportUnknownRuleNames(unknownRuleName, postcssRoot, pos
 		rule: unknownRuleName,
 		node: postcssRoot,
 		index: 0,
+		endIndex: 1,
 	});
 }


### PR DESCRIPTION
<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates #9382

> Is there anything in the PR that needs further explanation?

Currently, the reported range of unknown rules covers the whole root node. For example:

```css
   a {}
/* ^^^^ */
/* Unknown rule block-no-emptyy. Did you mean block-no-empty? */
```

This behavior depends on PostCSS internals, and it's been fixed in PostCSS v8.5.16 recently.
Ref: https://github.com/postcss/postcss/releases/tag/8.5.16

The changed behavior is just pointing to the first character in the root node.

```css
   a {}
/* ^ */
```

To keep the compatibility on the Stylelint side, this explicitly specifies `endIndex` along with `index: 0`.

You can confirm the compatibility between v8.5.15 and v8.5.16 for PostCSS like this (both pass):

```shell
npm i postcss@8.5.16
npm run test-jest -- lib/__tests__/reportUnknownRuleNames.test.mjs
```

In addition, this refactors the test code by using the `toMatchObject` matcher of Jest.
It makes expected results easier to read than `toContainEqual`.
Ref: https://jestjs.io/docs/expect#tomatchobjectobject