### PR TITLE
Fix `quiet` option to suppress `report*` warning reports

### DIFF
--- a/.changeset/quiet-report-warnings.md
+++ b/.changeset/quiet-report-warnings.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `quiet` option suppresses `report*` warning reports.

--- a/lib/__tests__/standalone-quiet.test.mjs
+++ b/lib/__tests__/standalone-quiet.test.mjs
@@ -69,3 +69,42 @@ it('standalone with custom rule using checkAgainstRule on quiet and reportNeedle
 
 	expect(results[0].warnings).toEqual([]);
 });
+
+it('standalone with quiet mode and report disable warning options', async () => {
+	const { results } = await standalone({
+		code: '/* stylelint-disable foo */\n/* stylelint-disable -- a description */',
+		config: {
+			reportDescriptionlessDisables: [true, { severity: 'warning' }],
+			reportInvalidScopeDisables: [true, { severity: 'warning' }],
+			reportNeedlessDisables: [true, { severity: 'warning' }],
+			reportUnscopedDisables: [true, { severity: 'warning' }],
+			quiet: true,
+			rules: {},
+		},
+	});
+
+	expect(results[0].warnings).toEqual([]);
+});
+
+it('standalone with quiet mode and report disable error options', async () => {
+	const { results } = await standalone({
+		code: '/* stylelint-disable foo */',
+		config: {
+			reportDescriptionlessDisables: [true, { severity: 'error' }],
+			quiet: true,
+			rules: {},
+		},
+	});
+
+	expect(results[0].warnings).toHaveLength(1);
+	expect(results[0].warnings[0]).toMatchObject({
+		line: 1,
+		column: 1,
+		endLine: 1,
+		endColumn: 27,
+		rule: '--report-descriptionless-disables',
+		severity: 'error',
+		text: 'Disable for "foo" is missing a description',
+	});
+	expect(results[0].errored).toBe(true);
+});

--- a/lib/utils/reportCommentProblem.mjs
+++ b/lib/utils/reportCommentProblem.mjs
@@ -17,6 +17,8 @@ export default function reportCommentProblem({ rule, message, severity, node, po
 	// In practice we expect all comments to have locations, though.
 	if (!source?.start) return;
 
+	if (postcssResult.stylelint.quiet && severity === SEVERITY_WARNING) return;
+
 	postcssResult.warn(message, {
 		rule,
 		severity,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #9375.

> Is there anything in the PR that needs further explanation?

`quiet` already suppresses regular warning-severity rule reports. The `report*Disables` options report through `reportCommentProblem()`, so they bypassed that check. This adds the same warning-only quiet guard there while keeping error-severity reports visible.

Validation:

- `node --input-type=module <standalone reproduction>` returned 0 warnings after the fix; returned 5 warnings before the fix
- `npm run test-jest --ignore-scripts -- lib/__tests__/standalone-quiet.test.mjs`
- `npm run test-jest --ignore-scripts -- lib/__tests__/standalone-quiet.test.mjs lib/__tests__/descriptionlessDisables.test.mjs lib/__tests__/invalidScopeDisables.test.mjs lib/__tests__/needlessDisables.test.mjs lib/__tests__/unscopedDisables.test.mjs lib/__tests__/reportDisables.test.mjs`
- `npx prettier --check .changeset/quiet-report-warnings.md lib/__tests__/standalone-quiet.test.mjs lib/utils/reportCommentProblem.mjs`
- `npx eslint lib/__tests__/standalone-quiet.test.mjs lib/utils/reportCommentProblem.mjs --max-warnings=0`
- `npx remark .changeset/quiet-report-warnings.md --quiet --frail`
- `npm run lint:types`
- `git diff --check`