### PR TITLE
Fix CI to work around Yarn PnP test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,13 @@ jobs:
           node-version: '24'
           cache: npm
 
-      - name: Install latest npm
-        run: npm install --global npm
+      # TODO: Bump to `npm@latest`. Yarn PnP system tests fail with npm v12.0.0 for some reason:
+      #
+      #   TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
+      #       at packStylelint (file:///home/runner/work/stylelint/stylelint/system-tests/006/yarn-pnp.test.mjs:87:25)
+      #
+      - name: Install npm 11
+        run: npm install --global npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Blocks #9388

> Is there anything in the PR that needs further explanation?

This PR uses npm v11 instead of v12 (latest) in the CI `test-coverage` job.

For example, see:
<https://github.com/stylelint/stylelint/actions/runs/28997230765/job/86049307694?pr=9388#step:8:45>

