### PR TITLE
Fix `rule-empty-line-before` false positives for shared-line comments with `except: ["after-single-line-comment"]`

### DIFF
--- a/.changeset/olive-pens-yawn.md
+++ b/.changeset/olive-pens-yawn.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `rule-empty-line-before` false positives for `except: ["after-single-line-comment"]` when the comment and the rule share a line
+Fixed: `rule-empty-line-before` false positives for shared-line comments with `except: ["after-single-line-comment"]`

--- a/.changeset/olive-pens-yawn.md
+++ b/.changeset/olive-pens-yawn.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `rule-empty-line-before` false positives for `except: ["after-single-line-comment"]` when the comment and the rule share a line

--- a/lib/rules/rule-empty-line-before/__tests__/index.mjs
+++ b/lib/rules/rule-empty-line-before/__tests__/index.mjs
@@ -304,6 +304,14 @@ testRule({
 			code: '@media { /* comment */\n\na {} }',
 			description: 'nested shared-line comment',
 		},
+		{
+			code: '/* comment */ a {}',
+			description: 'comment on the same line as the rule',
+		},
+		{
+			code: 'b {}\n/* comment */ a {}',
+			description: 'comment on its own line and on the same line as the rule',
+		},
 	],
 
 	reject: [

--- a/lib/utils/isAfterSingleLineComment.mjs
+++ b/lib/utils/isAfterSingleLineComment.mjs
@@ -8,9 +8,11 @@ import isSharedLineComment from './isSharedLineComment.mjs';
 export default function isAfterSingleLineComment(node) {
 	const prevNode = node.prev();
 
+	// A comment on the same line as `node` is still the comment `node` follows,
+	// so it's only shared when it also belongs to a preceding node or a block start.
 	return (
 		isComment(prevNode) &&
-		!isSharedLineComment(prevNode) &&
+		!isSharedLineComment(prevNode, node) &&
 		prevNode.source !== undefined &&
 		prevNode.source.start !== undefined &&
 		prevNode.source.end !== undefined &&

--- a/lib/utils/isSharedLineComment.mjs
+++ b/lib/utils/isSharedLineComment.mjs
@@ -17,9 +17,10 @@ function nodesShareLines(a, b) {
 
 /**
  * @param {PostcssNode} node
+ * @param {PostcssNode} [ignoredNode] - a node that doesn't count as sharing a line with `node`
  * @returns {boolean}
  */
-export default function isSharedLineComment(node) {
+export default function isSharedLineComment(node, ignoredNode) {
 	if (!isComment(node)) {
 		return false;
 	}
@@ -32,7 +33,11 @@ export default function isSharedLineComment(node) {
 
 	const nextNonSharedLineCommentNode = getNextNonSharedLineCommentNode(node);
 
-	if (nextNonSharedLineCommentNode && nodesShareLines(node, nextNonSharedLineCommentNode)) {
+	if (
+		nextNonSharedLineCommentNode &&
+		nextNonSharedLineCommentNode !== ignoredNode &&
+		nodesShareLines(node, nextNonSharedLineCommentNode)
+	) {
 		return true;
 	}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None open. I hit it while checking that `--fix` is idempotent across the rules.

> Is there anything in the PR that needs further explanation?

With `["always", { except: ["after-single-line-comment"] }]`, a rule that starts on the same line as its comment is flagged, and autofix doesn't settle:

<!-- prettier-ignore -->
```css
/* comment */ a {}
```

The first pass inserts a blank line. Running it again reports the opposite problem and takes the blank line back out, so `stylelint --fix` twice gives a different file than once. Same for a comment that starts its own line but shares the next one, e.g. `b {}` then `/* comment */ a {}`.

The exception is skipped because `isAfterSingleLineComment` discounts any shared-line comment, and a comment counts as shared-line if it's on the same line as the node *after* it — which here is the rule being checked. Once the fix adds the newline they're no longer on one line, the exception applies, and the fix undoes itself.

So I made `isAfterSingleLineComment` disregard that one reason. A comment is still discounted when it trails a preceding node or opens a block, which is what the existing `a {} /* comment */` and `@media { /* comment */` cases rely on — those go through the other two checks and are unchanged.

Two accept cases added; both fail on main. Jest, ESLint, Prettier, `tsc` and remark pass locally.
