### PR TITLE
Refactor to replace `void` with `undefined` in union types

### DIFF
--- a/lib/utils/eachNodeUpToRoot.mjs
+++ b/lib/utils/eachNodeUpToRoot.mjs
@@ -8,7 +8,7 @@ export const STOP = 'STOP';
  * Iterates over each node up to the root node.
  *
  * @param {Node} node
- * @param {(node: Node) => void | STOP} callback
+ * @param {(node: Node) => STOP | undefined} callback
  * @returns {void}
  */
 export default function eachNodeUpToRoot(node, callback) {

--- a/lib/utils/getNextNonSharedLineCommentNode.mjs
+++ b/lib/utils/getNextNonSharedLineCommentNode.mjs
@@ -3,15 +3,15 @@ import { isComment } from './typeGuards.mjs';
 /** @import { Node } from 'postcss' */
 
 /**
- * @param {Node | void} node
+ * @param {Node | undefined} node
  */
 function getNodeLine(node) {
 	return node && node.source && node.source.start && node.source.start.line;
 }
 
 /**
- * @param {Node | void} node
- * @returns {Node | void}
+ * @param {Node | undefined} node
+ * @returns {Node | undefined}
  */
 export default function getNextNonSharedLineCommentNode(node) {
 	if (node === undefined) {

--- a/lib/utils/isSharedLineComment.mjs
+++ b/lib/utils/isSharedLineComment.mjs
@@ -5,8 +5,8 @@ import getPreviousNonSharedLineCommentNode from './getPreviousNonSharedLineComme
 /** @import { Node as PostcssNode } from 'postcss' */
 
 /**
- * @param {PostcssNode | void} a
- * @param {PostcssNode | void} b
+ * @param {PostcssNode | undefined} a
+ * @param {PostcssNode | undefined} b
  */
 function nodesShareLines(a, b) {
 	const endLine = a && a.source && a.source.end && a.source.end.line;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`void` represents "the return value of functions which don't return a value" and is not the same as `undefined`. So a union like `X | void` is a misuse of `undefined`.

See <https://www.typescriptlang.org/docs/handbook/2/functions.html#void>

