### PR TITLE
Use `node-version: latest` instead of `lts/*` for `actions/setup-node`

### DIFF
--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: latest
           cache: npm
@@ -45,5 +47,5 @@ jobs:
         with:
           name: output
           path: ./output.json
-
-      - run: ls -R .
+      - name: Check current directory
+        run: ls -R .

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 'lts/*'
+          node-version: latest
           cache: npm
       - name: Install Packages
         run: npm ci

--- a/.github/workflows/update-pkg.pr.new-comment.yml
+++ b/.github/workflows/update-pkg.pr.new-comment.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 'lts/*'
+          node-version: latest
           cache: npm
       - name: Install Packages
         run: npm ci

--- a/.github/workflows/update-pkg.pr.new-comment.yml
+++ b/.github/workflows/update-pkg.pr.new-comment.yml
@@ -22,14 +22,17 @@ jobs:
     name: Update comment
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: latest
           cache: npm
       - name: Install Packages
         run: npm ci
-      - run: mkdir -p ${{ runner.temp }}/artifacts/
+      - name: Create artifacts directory
+        run: mkdir -p ${{ runner.temp }}/artifacts/
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -37,7 +40,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
           path: ${{ runner.temp }}/artifacts/
-      - run: ls -R ${{ runner.temp }}/artifacts/
+      - name: Check artifacts directory
+        run: ls -R ${{ runner.temp }}/artifacts/
       - name: Post or update comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Resolving an LTS alias requires fetching the manifest, which may fail for various reasons, including network issues.

Ref: <https://github.com/actions/setup-node/blob/b789df37d6b7526a863bf51b65df64f3f56ffe4f/src/distributions/official_builds/official_builds.ts#L24>

So this switches from the LTS alias to the latest version of Node.js in the existing workflows.

I also think that using the latest version is a good practice for common tasks.

In addition, this provides more readable step names in the updated workflows.