### PR TITLE
Document summary and item order of latest release in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 17.14.1 - 2026-07-20
 
-- Fixed: `declaration-block-no-redundant-longhand-properties` autofix producing invalid `background` shorthand when `background-size` is present ([#9364](https://github.com/stylelint/stylelint/pull/9364)) ([@sarathfrancis90](https://github.com/sarathfrancis90)).
+It fixes 4 bugs.
+
 - Fixed: `quiet` option suppresses `report*` warning reports ([#9387](https://github.com/stylelint/stylelint/pull/9387)) ([@ychampion](https://github.com/ychampion)).
-- Fixed: `rule-empty-line-before` false positives for shared-line comments with `except: ["after-single-line-comment"]` ([#9394](https://github.com/stylelint/stylelint/pull/9394)) ([@sarathfrancis90](https://github.com/sarathfrancis90)).
 - Fixed: reported range of unknown rules ([#9385](https://github.com/stylelint/stylelint/pull/9385)) ([@ybiquitous](https://github.com/ybiquitous)).
+- Fixed: `declaration-block-no-redundant-longhand-properties` autofix producing invalid `background` shorthand when `background-size` is present ([#9364](https://github.com/stylelint/stylelint/pull/9364)) ([@sarathfrancis90](https://github.com/sarathfrancis90)).
+- Fixed: `rule-empty-line-before` false positives for shared-line comments with `except: ["after-single-line-comment"]` ([#9394](https://github.com/stylelint/stylelint/pull/9394)) ([@sarathfrancis90](https://github.com/sarathfrancis90)).
 
 ## 17.14.0 - 2026-06-25
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix to make things consistent.

> Is there anything in the PR that needs further explanation?

The PR:
- adds a summary
- reorders so that the widest-reaching changes come first, which generally means single rule fixes come last.

I've made the same changes to the [GitHub release](https://github.com/stylelint/stylelint/releases/tag/17.14.1), too

I've also opened a PR to tweak the wording in the release PR to help remind us:
- https://github.com/stylelint/.github/pull/125

