### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` autofix for `font` shorthand

### DIFF
--- a/.changeset/tame-planets-clap.md
+++ b/.changeset/tame-planets-clap.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix producing an invalid `font` shorthand without a slash before `line-height`

--- a/.changeset/tame-planets-clap.md
+++ b/.changeset/tame-planets-clap.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `declaration-block-no-redundant-longhand-properties` autofix producing an invalid `font` shorthand without a slash before `line-height`
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `font` shorthand

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -182,7 +182,7 @@ testRule({
 		},
 		{
 			code: 'a { font-style: italic; font-variant: normal; font-weight: bold; font-size: .8em; font-family: Arial; line-height: 1.2; font-stretch: normal; }',
-			fixed: 'a { font: italic normal bold normal .8em 1.2 Arial; }',
+			fixed: 'a { font: italic normal bold normal .8em/1.2 Arial; }',
 			message: messages.expected('font'),
 			line: 1,
 			column: 5,
@@ -190,7 +190,21 @@ testRule({
 			endColumn: 142,
 			fix: {
 				range: [8, 138],
-				text: ': italic normal bold normal .8em 1.2 Ari',
+				text: ': italic normal bold normal .8em/1.2 Ari',
+			},
+		},
+		{
+			code: 'a { font-style: normal; font-variant: normal; font-weight: 400; font-stretch: normal; font-size: 16px; line-height: normal; font-family: serif; }',
+			fixed: 'a { font: normal normal 400 normal 16px/normal serif; }',
+			description: 'font with `line-height: normal` keeps the slash',
+			message: messages.expected('font'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 144,
+			fix: {
+				range: [8, 136],
+				text: ': normal normal 400 normal 16px/normal',
 			},
 		},
 		{

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -32,6 +32,24 @@ const meta = {
 /** @type {Map<string, (decls: Map<string, Declaration>) => (string | undefined)>} */
 const customResolvers = new Map([
 	[
+		'font',
+		(decls) => {
+			const style = decls.get('font-style')?.value.trim();
+			const variant = decls.get('font-variant')?.value.trim();
+			const weight = decls.get('font-weight')?.value.trim();
+			const stretch = decls.get('font-stretch')?.value.trim();
+			const size = decls.get('font-size')?.value.trim();
+			const lineHeight = decls.get('line-height')?.value.trim();
+			const family = decls.get('font-family')?.value.trim();
+
+			if (!(style && variant && weight && stretch && size && lineHeight && family)) return;
+
+			// `line-height` must directly follow `font-size`, separated by a slash.
+			// Spec ref: https://drafts.csswg.org/css-fonts/#font-prop
+			return `${style} ${variant} ${weight} ${stretch} ${size}/${lineHeight} ${family}`;
+		},
+	],
+	[
 		'font-synthesis',
 		(decls) => {
 			const weight = decls.get('font-synthesis-weight')?.value.trim();


### PR DESCRIPTION
## Which issue, if any, is this issue related to?

None open. It's the same class of invalid-autofix bug as #9364 (which bailed on `background`/`background-size`), but the `font` case has a simple correct form.

## Is there anything in the PR that needs further explanation?

### The problem

When all of the `font` longhands are present, the autofix combines them into an invalid `font` shorthand because it drops the slash between `font-size` and `line-height`:

```css
a {
  font-style: italic;
  font-variant: normal;
  font-weight: bold;
  font-stretch: normal;
  font-size: 16px;
  line-height: 1.5;
  font-family: serif;
}
```

is fixed to

```css
a { font: italic normal bold normal 16px 1.5 serif; }
```

In the shorthand, `line-height` may only appear immediately after `font-size`, separated by a `/`. Here `16px 1.5` doesn't parse as a font value, so a browser drops the whole declaration. The rule's own README already shows the correct output, `font: italic normal bold normal 14px/1.2 serif`.

### The fix

The default resolver space-joins the longhand values in property order, which can't express the `font-size/line-height` form. I added a `font` resolver (alongside the existing `grid-column`/`grid-row` ones) that inserts the required slash, so the autofix produces valid CSS.

I corrected the existing `font` reject case, which asserted the invalid slash-less output, and added a case with `line-height: normal`. The new/updated cases fail on `main` and pass with this change. Rule tests, ESLint, Prettier, remark, and types pass locally.
