### PR TITLE
Fix unknown effort workflow

### DIFF
--- a/.github/workflows/close-unknown-effort-prs.yml
+++ b/.github/workflows/close-unknown-effort-prs.yml
@@ -1,4 +1,4 @@
-name: Close unknown-effort PRs
+name: Close unknown effort PRs
 
 on:
   pull_request_target:
@@ -13,11 +13,11 @@ jobs:
     if: >-
       github.repository == 'stylelint/stylelint' &&
       github.event_name == 'pull_request_target' &&
-      github.event.label.name == 'pr: unknown-effort'
+      github.event.label.name == 'pr: unknown effort'
     permissions:
       pull-requests: write
     steps:
-      - name: Comment on unknown-effort PR
+      - name: Comment on unknown effort PR
         run: gh pr comment "${PR_URL}" --body "${PR_COMMENT}"
         env:
           GH_REPO: ${{ github.repository }}
@@ -49,7 +49,7 @@ jobs:
 
           # For the search syntax, see https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
           old_pr_urls=$(gh pr list \
-            --search "is:open updated:<${two_days_ago} label:\"pr: unknown-effort\"" \
+            --search "is:open updated:<${two_days_ago} label:\"pr: unknown effort\"" \
             --json 'url' \
             --jq '.[] | .url')
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

The workflow didn't trigger when adding the label to https://github.com/stylelint/stylelint/pull/9419

> Is there anything in the PR that needs further explanation?

We don't use hyphens to separate words in our labels. My mistake when updating the workflow last time.
