### PR TITLE
Add `concurrency` option

### DIFF
--- a/.changeset/tall-hoops-refuse.md
+++ b/.changeset/tall-hoops-refuse.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `concurrency` option to lint files in parallel using worker threads

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -977,6 +977,25 @@ For example:
 
 [More info](options.md#cache).
 
+## `concurrency`
+
+Lint files in parallel using [worker threads](https://nodejs.org/api/worker_threads.html). The value is either a positive integer setting the number of workers, or `"auto"`, which sizes the worker pool based on the available CPU cores and the number of files.
+
+For example:
+
+```json
+{
+  "concurrency": "auto"
+}
+```
+
+The [CLI flag](options.md#concurrency) takes precedence over this property.
+
+> [!NOTE]
+> This config option should not be overridden on a per-file basis.
+
+[More info](options.md#concurrency).
+
 ## `fix`
 
 Automatically fix, where possible, problems reported by rules.

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -64,6 +64,27 @@ The edit information will not be computed when:
 
 See [Node.js API Warning details](./node-api.md#edit-info).
 
+## `concurrency`
+
+CLI flag: `--concurrency`
+
+Lint files in parallel using [worker threads](https://nodejs.org/api/worker_threads.html). The value is either a positive integer setting the number of workers, or `"auto"`, which sizes the worker pool based on the available CPU cores and the number of files. By default, files are linted in the main thread.
+
+For example, to size the pool automatically:
+
+```shell
+stylelint "**/*.css" --concurrency auto
+```
+
+Parallel linting speeds up large runs, e.g. linting a whole project in CI. For small runs, the worker startup cost can outweigh the gain; `"auto"` accounts for this by linting in the main thread when there are few files.
+
+The option:
+
+- produces the same results and output as linting in the main thread, in the same order
+- only applies when linting files; it is ignored when linting `code` via the Node.js API or stdin
+- requires options that can be passed to worker threads when using the Node.js API, e.g. a `config` object must not contain functions such as inline plugins; use `configFile` for such configurations
+- cannot be combined with the [`cache`](#cache) option yet
+
 ## `customSyntax`
 
 CLI flag: `--custom-syntax`

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -83,6 +83,7 @@ The option:
 - produces the same results and output as linting in the main thread, in the same order
 - only applies when linting files; it is ignored when linting `code` via the Node.js API or stdin
 - requires options that can be passed to worker threads when using the Node.js API, e.g. a `config` object must not contain functions such as inline plugins; use `configFile` for such configurations
+- fails with a regular error when a worker runs out of memory, rather than crashing the process; each worker gets the same memory limit as the main thread
 - combines with the [`cache`](#cache) option: only the files that changed are linted in workers, and a warm-cache run with few changed files stays in the main thread
 
 ## `customSyntax`

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -83,7 +83,7 @@ The option:
 - produces the same results and output as linting in the main thread, in the same order
 - only applies when linting files; it is ignored when linting `code` via the Node.js API or stdin
 - requires options that can be passed to worker threads when using the Node.js API, e.g. a `config` object must not contain functions such as inline plugins; use `configFile` for such configurations
-- cannot be combined with the [`cache`](#cache) option yet
+- combines with the [`cache`](#cache) option: only the files that changed are linted in workers, and a warm-cache run with few changed files stays in the main thread
 
 ## `customSyntax`
 

--- a/lib/__tests__/__snapshots__/cli.test.mjs.snap
+++ b/lib/__tests__/__snapshots__/cli.test.mjs.snap
@@ -66,6 +66,13 @@ exports[`CLI --help 1`] = `
 
       A module name or path to a JS file exporting a PostCSS-compatible syntax.
 
+    --concurrency <count>
+
+      Lint files in parallel using worker threads. The count is either a
+      positive integer or "auto", which sizes the worker pool based on the
+      available CPU cores and the number of files. By default, files are
+      linted in the main thread.
+
     --stdin
 
       Accept stdin input even if it is empty.

--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -525,6 +525,18 @@ describe('CLI', () => {
 		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('deprecations: [],'));
 	});
 
+	it('--concurrency=auto lints successfully', async () => {
+		await cli([
+			'--concurrency=auto',
+			'--config',
+			fixturesPath('config-block-no-empty.json'),
+			fixturesPath('empty-block.css'),
+		]);
+
+		expect(process.exitCode).toBe(EXIT_CODE_LINT_PROBLEM);
+		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('block-no-empty'));
+	});
+
 	it('--concurrency lints across worker threads', async () => {
 		await cli([
 			'--concurrency=2',

--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -195,6 +195,11 @@ describe('buildCLI', () => {
 		expect(buildCLI(['-v']).flags.version).toBe(true);
 	});
 
+	it('flags.concurrency', () => {
+		expect(buildCLI(['--concurrency=4']).flags.concurrency).toBe('4');
+		expect(buildCLI(['--concurrency=auto']).flags.concurrency).toBe('auto');
+	});
+
 	it('flags.computeEditInfo', () => {
 		expect(buildCLI(['--compute-edit-info']).flags.computeEditInfo).toBe(true);
 		expect(buildCLI(['--cei']).flags.computeEditInfo).toBe(true);
@@ -518,6 +523,33 @@ describe('CLI', () => {
 		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('deprecations: [],'));
+	});
+
+	it('--concurrency lints across worker threads', async () => {
+		await cli([
+			'--concurrency=2',
+			'--config',
+			fixturesPath('config-block-no-empty.json'),
+			fixturesPath('empty-block.css'),
+			fixturesPath('empty-block-with-disables.css'),
+		]);
+
+		expect(process.exitCode).toBe(EXIT_CODE_LINT_PROBLEM);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('block-no-empty'));
+	});
+
+	it('output a message when wrong --concurrency provided', async () => {
+		await cli(['--concurrency=wrong', fixturesPath('empty-block.css')]);
+
+		expect(process.exitCode).toBe(EXIT_CODE_INVALID_USAGE);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(stripVTControlCharacters(process.stderr.write.mock.calls[0][0])).toContain(
+			'Invalid value "wrong" for "--concurrency". Expected "auto" or a positive integer.',
+		);
 	});
 
 	it('output a message when wrong --globby-options provided', async () => {

--- a/lib/__tests__/fixtures/worker-resource-limits-syntax.mjs
+++ b/lib/__tests__/fixtures/worker-resource-limits-syntax.mjs
@@ -1,0 +1,10 @@
+import { resourceLimits } from 'node:worker_threads';
+
+// Surfaces the worker's own resource limits through the error-propagation
+// path, so a test can assert workers run with an explicit memory limit.
+export default {
+	parse() {
+		throw new Error(`maxOldGenerationSizeMb=${resourceLimits.maxOldGenerationSizeMb}`);
+	},
+	stringify() {},
+};

--- a/lib/__tests__/lintFilesInWorkers.test.mjs
+++ b/lib/__tests__/lintFilesInWorkers.test.mjs
@@ -1,0 +1,91 @@
+import * as fs from 'node:fs/promises';
+import { availableParallelism } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import lintFilesInWorkers, {
+	resolveWorkerCount,
+	validateConcurrency,
+} from '../lintFilesInWorkers.mjs';
+import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
+
+const fixturesPath = (...elems) =>
+	replaceBackslashes(path.join(fileURLToPath(new URL('./fixtures', import.meta.url)), ...elems));
+
+const cssTmpDir = fixturesPath('tmp', 'lint-files-in-workers');
+
+const config = { rules: { 'block-no-empty': true } };
+
+const cssFiles = Array.from({ length: 4 }, (_unused, i) => path.join(cssTmpDir, `file-${i}.css`));
+
+beforeAll(async () => {
+	await fs.mkdir(cssTmpDir, { recursive: true });
+	await Promise.all(cssFiles.map((file) => fs.writeFile(file, 'a { color: #fff; }\n')));
+});
+
+afterAll(async () => {
+	await fs.rm(cssTmpDir, { recursive: true });
+});
+
+describe('validateConcurrency', () => {
+	it.each([undefined, 'auto', 1, 8])('accepts %s', (value) => {
+		expect(() => validateConcurrency(value)).not.toThrow();
+	});
+
+	it.each([0, -1, 2.5, Number.NaN, 'four', true])('rejects %s', (value) => {
+		expect(() => validateConcurrency(value)).toThrow(/expected "auto" or a positive integer/);
+	});
+});
+
+describe('resolveWorkerCount', () => {
+	it('resolves to the main thread without the option', () => {
+		expect(resolveWorkerCount(undefined, 1000)).toBe(1);
+	});
+
+	it('caps a worker count at the file count', () => {
+		expect(resolveWorkerCount(8, 2)).toBe(2);
+		expect(resolveWorkerCount(8, 0)).toBe(1);
+	});
+
+	it('resolves "auto" to the main thread for small runs', () => {
+		expect(resolveWorkerCount('auto', 128)).toBe(1);
+	});
+
+	it('resolves "auto" to at most half the available cores', () => {
+		const workerCount = resolveWorkerCount('auto', 1_000_000);
+
+		expect(workerCount).toBeGreaterThanOrEqual(1);
+		expect(workerCount).toBeLessThanOrEqual(Math.max(1, Math.floor(availableParallelism() / 2)));
+	});
+});
+
+describe('lintFilesInWorkers', () => {
+	it('rejects with the worker error when a task fails in a worker', async () => {
+		await expect(
+			lintFilesInWorkers(cssFiles, { config, customSyntax: 'this-module-does-not-exist' }, 2),
+		).rejects.toThrow(/this-module-does-not-exist/);
+	});
+
+	it('rejects when a worker fails to start', async () => {
+		await expect(
+			lintFilesInWorkers(cssFiles, { config, cacheStrategy: 'bogus' }, 2),
+		).rejects.toThrow(/cache strategy/);
+	});
+
+	it('rejects when the signal is already aborted', async () => {
+		const reason = new Error('aborted before linting');
+
+		await expect(
+			lintFilesInWorkers(cssFiles, { config }, 2, AbortSignal.abort(reason)),
+		).rejects.toThrow(reason);
+	});
+
+	it('rejects when the signal aborts during linting', async () => {
+		const controller = new AbortController();
+		const lintPromise = lintFilesInWorkers(cssFiles, { config }, 2, controller.signal);
+
+		controller.abort(new Error('aborted during linting'));
+
+		await expect(lintPromise).rejects.toThrow('aborted during linting');
+	});
+});

--- a/lib/__tests__/lintWorker-no-parent-port.test.mjs
+++ b/lib/__tests__/lintWorker-no-parent-port.test.mjs
@@ -1,0 +1,12 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('node:worker_threads', () => ({
+	parentPort: null,
+	workerData: undefined,
+}));
+
+it('throws when imported outside a worker thread', async () => {
+	await expect(import('../lintWorker.mjs')).rejects.toThrow(
+		'This module must be run in a worker thread',
+	);
+});

--- a/lib/__tests__/lintWorker.test.mjs
+++ b/lib/__tests__/lintWorker.test.mjs
@@ -1,0 +1,186 @@
+import * as fs from 'node:fs/promises';
+import { EventEmitter } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { jest } from '@jest/globals';
+
+import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
+
+const fixturesPath = (...elems) =>
+	replaceBackslashes(path.join(fileURLToPath(new URL('./fixtures', import.meta.url)), ...elems));
+
+const cssTmpDir = fixturesPath('tmp', 'lint-worker');
+
+// The worker module reads `parentPort` and `workerData` from
+// `node:worker_threads` at import time. Mocking them runs the worker's
+// message handling in the main thread, where Jest can instrument it, and the
+// `EventEmitter` stands in for the real `MessagePort`.
+class FakeParentPort extends EventEmitter {
+	postMessage(message) {
+		this.emit('posted', message);
+	}
+}
+
+const port = new FakeParentPort();
+
+// An inline plugin may only be used here because no real thread boundary is
+// involved. Throwing outside a PostCSS `walk*` callback keeps the thrown
+// value as is; a non-`Error` value exercises the worker's serialization
+// fallback, and the `Error` with a `code` exercises custom-property carrying.
+const throwOnMatchRule = Object.assign(
+	() => (root) => {
+		const file = root.source?.input.file ?? '';
+
+		if (file.endsWith('throw-string.css')) {
+			throw 'a non-error value';
+		}
+
+		if (file.endsWith('throw-error-code.css')) {
+			throw Object.assign(new Error('task failed'), { code: 78 });
+		}
+	},
+	{ ruleName: 'plugin/throw-on-match' },
+);
+
+jest.unstable_mockModule('node:worker_threads', () => ({
+	parentPort: port,
+	workerData: {
+		options: {
+			config: {
+				plugins: [{ ruleName: 'plugin/throw-on-match', rule: throwOnMatchRule }],
+				rules: {
+					'block-no-empty': true,
+					'plugin/throw-on-match': true,
+					'selector-attribute-quotes': 'always',
+				},
+			},
+		},
+	},
+}));
+
+await import('../lintWorker.mjs');
+
+const lintInWorker = (files) => {
+	const response = new Promise((resolve) => port.once('posted', resolve));
+
+	port.emit('message', { files });
+
+	return response;
+};
+
+beforeAll(async () => {
+	await fs.mkdir(cssTmpDir, { recursive: true });
+	await fs.writeFile(path.join(cssTmpDir, 'clean.css'), 'a { color: #fff; }\n');
+	await fs.writeFile(path.join(cssTmpDir, 'empty-block.css'), 'a {}\n');
+	await fs.writeFile(path.join(cssTmpDir, 'broken.css'), 'a { color: #fff;\n');
+	await fs.writeFile(path.join(cssTmpDir, 'parse-error.css'), 'a[=] { color: #fff; }\n');
+	await fs.writeFile(path.join(cssTmpDir, 'throw-string.css'), 'a { top: 0; }\n');
+	await fs.writeFile(path.join(cssTmpDir, 'throw-error-code.css'), 'a { top: 0; }\n');
+});
+
+afterAll(async () => {
+	await fs.rm(cssTmpDir, { recursive: true });
+});
+
+it('lints a task and posts one transferable result per file', async () => {
+	const cleanFile = path.join(cssTmpDir, 'clean.css');
+	const emptyBlockFile = path.join(cssTmpDir, 'empty-block.css');
+
+	const response = await lintInWorker([cleanFile, emptyBlockFile]);
+
+	expect(response.error).toBeUndefined();
+	expect(response.results).toHaveLength(2);
+
+	const [clean, emptyBlock] = response.results;
+
+	expect(clean).toMatchObject({ source: cleanFile, errored: false, warnings: [] });
+	expect(emptyBlock).toMatchObject({
+		source: emptyBlockFile,
+		errored: true,
+		warnings: [expect.objectContaining({ rule: 'block-no-empty' })],
+	});
+
+	// The stub keeps only the fields the main thread reads after linting.
+	expect(Object.keys(emptyBlock._postcssResult)).toEqual(['stylelint']);
+	expect(Object.keys(emptyBlock._postcssResult.stylelint).sort()).toEqual([
+		'fixersData',
+		'ruleMetadata',
+		'stylelintError',
+		'stylelintWarning',
+	]);
+	expect(emptyBlock._postcssResult.stylelint.stylelintError).toBe(true);
+
+	// The whole response must survive a real `postMessage()`.
+	expect(() => structuredClone(response)).not.toThrow();
+});
+
+it('maps parse errors to plain transferable objects', async () => {
+	const parseErrorFile = path.join(cssTmpDir, 'parse-error.css');
+
+	const response = await lintInWorker([parseErrorFile]);
+
+	expect(response.results).toHaveLength(1);
+	expect(response.results[0].parseErrors).toEqual([
+		{
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 22,
+			text: expect.stringContaining('Cannot parse selector'),
+			stylelintType: 'parseError',
+		},
+	]);
+	expect(() => structuredClone(response)).not.toThrow();
+});
+
+it('posts a CSS syntax error result without a PostCSS result', async () => {
+	const brokenFile = path.join(cssTmpDir, 'broken.css');
+
+	const response = await lintInWorker([brokenFile]);
+
+	expect(response.results).toHaveLength(1);
+	expect(response.results[0]).toMatchObject({
+		source: brokenFile,
+		errored: true,
+		warnings: [expect.objectContaining({ rule: 'CssSyntaxError' })],
+	});
+	expect(response.results[0]._postcssResult).toBeUndefined();
+	expect(() => structuredClone(response)).not.toThrow();
+});
+
+it('posts a serialized error when a task fails', async () => {
+	const response = await lintInWorker([path.join(cssTmpDir, 'does-not-exist.css')]);
+
+	expect(response.results).toBeUndefined();
+	expect(response.error).toMatchObject({
+		name: 'Error',
+		message: expect.stringContaining('does-not-exist.css'),
+		stack: expect.stringContaining('Error'),
+		properties: expect.objectContaining({ code: 'ENOENT' }),
+	});
+	expect(() => structuredClone(response)).not.toThrow();
+});
+
+it('carries custom error properties across the serialization', async () => {
+	const response = await lintInWorker([path.join(cssTmpDir, 'throw-error-code.css')]);
+
+	expect(response.error).toMatchObject({
+		name: 'Error',
+		message: 'task failed',
+		properties: { code: 78 },
+	});
+	expect(() => structuredClone(response)).not.toThrow();
+});
+
+it('serializes a thrown non-error value', async () => {
+	const response = await lintInWorker([path.join(cssTmpDir, 'throw-string.css')]);
+
+	expect(response.error).toMatchObject({
+		name: 'Error',
+		message: 'a non-error value',
+		stack: undefined,
+		properties: {},
+	});
+	expect(() => structuredClone(response)).not.toThrow();
+});

--- a/lib/__tests__/standalone-abort-signal.test.mjs
+++ b/lib/__tests__/standalone-abort-signal.test.mjs
@@ -83,6 +83,27 @@ describe('standalone with abortSignal', () => {
 			).rejects.toThrow('This operation was aborted');
 		});
 
+		it('rejects when the signal aborts while a file is being linted', async () => {
+			const controller = new AbortController();
+			const abortingRule = Object.assign(
+				() => () => {
+					controller.abort(new Error('Aborted mid-lint'));
+				},
+				{ ruleName: 'plugin/abort-mid-lint' },
+			);
+
+			await expect(
+				standalone({
+					files: `${fixturesPath}/empty-block.css`,
+					config: {
+						plugins: [{ ruleName: 'plugin/abort-mid-lint', rule: abortingRule }],
+						rules: { 'plugin/abort-mid-lint': true },
+					},
+					abortSignal: controller.signal,
+				}),
+			).rejects.toThrow('Aborted mid-lint');
+		});
+
 		it('rejects with a custom abort reason', async () => {
 			const controller = new AbortController();
 

--- a/lib/__tests__/standalone-concurrency.test.mjs
+++ b/lib/__tests__/standalone-concurrency.test.mjs
@@ -1,0 +1,160 @@
+import * as fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
+import standalone from '../standalone.mjs';
+
+const fixturesPath = (...elems) =>
+	replaceBackslashes(path.join(fileURLToPath(new URL('./fixtures', import.meta.url)), ...elems));
+
+const cssTmpDir = fixturesPath('tmp', 'concurrency');
+
+const config = {
+	rules: {
+		'block-no-empty': true,
+		'color-named': 'never',
+	},
+};
+
+const cleanCss = 'a { color: #fff; }\n';
+const warningCss = 'a { color: red; }\nb {}\n';
+const brokenCss = 'a { color: red;\n';
+
+/** @param {import('stylelint').LinterOptions} [options] */
+const lintTmpDir = (options) =>
+	standalone({
+		files: `${cssTmpDir}/*.css`,
+		config,
+		...options,
+	});
+
+beforeEach(async () => {
+	await fs.mkdir(cssTmpDir, { recursive: true });
+
+	const writes = [];
+
+	for (let i = 0; i < 9; i++) {
+		writes.push(fs.writeFile(path.join(cssTmpDir, `warning-${i}.css`), warningCss));
+	}
+
+	writes.push(fs.writeFile(path.join(cssTmpDir, 'clean.css'), cleanCss));
+	writes.push(fs.writeFile(path.join(cssTmpDir, 'broken.css'), brokenCss));
+
+	await Promise.all(writes);
+});
+
+afterEach(async () => {
+	await fs.rm(cssTmpDir, { recursive: true });
+});
+
+describe('standalone with concurrency', () => {
+	it('produces the same public output as linting in the main thread', async () => {
+		const serial = await lintTmpDir({ formatter: 'json' });
+		const parallel = await lintTmpDir({ formatter: 'json', concurrency: 2 });
+
+		expect(parallel.report).toBe(serial.report);
+		expect(parallel.errored).toBe(serial.errored);
+		expect(parallel.ruleMetadata).toEqual(serial.ruleMetadata);
+		expect(parallel.results.map((result) => result.source)).toEqual(
+			serial.results.map((result) => result.source),
+		);
+	});
+
+	it('produces the same report with the string formatter', async () => {
+		const serial = await lintTmpDir({ formatter: 'string' });
+		const parallel = await lintTmpDir({ formatter: 'string', concurrency: 3 });
+
+		expect(parallel.report).toBe(serial.report);
+	});
+
+	it('reports CSS syntax errors like the main thread does', async () => {
+		const { results } = await lintTmpDir({ concurrency: 2 });
+		const brokenResult = results.find((result) => result.source?.endsWith('broken.css'));
+
+		expect(brokenResult).toMatchObject({
+			errored: true,
+			warnings: [expect.objectContaining({ rule: 'CssSyntaxError' })],
+		});
+	});
+
+	it('supports the maxWarnings option', async () => {
+		const { maxWarningsExceeded } = await lintTmpDir({ concurrency: 2, maxWarnings: 3 });
+
+		expect(maxWarningsExceeded).toMatchObject({ maxWarnings: 3, foundWarnings: 19 });
+	});
+
+	it('writes fixes to disk', async () => {
+		const fixConfig = { rules: { 'color-hex-length': 'short' } };
+
+		await fs.writeFile(path.join(cssTmpDir, 'fix-target.css'), 'a { color: #ffffff; }\n');
+
+		const { results } = await standalone({
+			files: `${cssTmpDir}/fix-*.css`,
+			config: fixConfig,
+			fix: true,
+			concurrency: 2,
+		});
+
+		const fixedCss = await fs.readFile(path.join(cssTmpDir, 'fix-target.css'), 'utf8');
+
+		expect(fixedCss).toBe('a { color: #fff; }\n');
+		expect(results[0].autofixed).toBe(true);
+	});
+
+	it('accepts "auto"', async () => {
+		const { results, errored } = await lintTmpDir({ concurrency: 'auto' });
+
+		expect(results).toHaveLength(11);
+		expect(errored).toBe(true);
+	});
+
+	it('lints in the main thread with a concurrency of one', async () => {
+		const serial = await lintTmpDir({ formatter: 'json' });
+		const single = await lintTmpDir({ formatter: 'json', concurrency: 1 });
+
+		expect(single.report).toBe(serial.report);
+	});
+
+	it('propagates worker errors like the main thread does', async () => {
+		const options = { customSyntax: 'this-module-does-not-exist' };
+
+		const serialError = await lintTmpDir(options).catch((error) => error);
+		const parallelError = await lintTmpDir({ ...options, concurrency: 2 }).catch((error) => error);
+
+		expect(serialError.message).toBeTruthy();
+		expect(parallelError.message).toBe(serialError.message);
+		expect(parallelError.name).toBe(serialError.name);
+	});
+
+	it('rejects options that cannot be passed to worker threads', async () => {
+		await expect(
+			lintTmpDir({
+				concurrency: 2,
+				config: { ...config, plugins: [{ ruleName: 'plugin/foo', rule: () => () => {} }] },
+			}),
+		).rejects.toThrow(/requires options that can be passed to worker threads/);
+	});
+
+	it('rejects the cache option', async () => {
+		await expect(lintTmpDir({ concurrency: 2, cache: true })).rejects.toThrow(
+			/The "cache" option is not supported when the "concurrency" option is enabled/,
+		);
+	});
+
+	it.each([0, -1, 1.5, Number.NaN, 'many'])('rejects an invalid value: %s', async (value) => {
+		await expect(lintTmpDir({ concurrency: value })).rejects.toThrow(
+			/expected "auto" or a positive integer/,
+		);
+	});
+
+	it('is ignored when linting a code string', async () => {
+		const { results } = await standalone({
+			code: 'a { color: red; }',
+			config,
+			concurrency: 4,
+		});
+
+		expect(results[0].warnings).toHaveLength(1);
+	});
+});

--- a/lib/__tests__/standalone-concurrency.test.mjs
+++ b/lib/__tests__/standalone-concurrency.test.mjs
@@ -136,9 +136,28 @@ describe('standalone with concurrency', () => {
 		).rejects.toThrow(/requires options that can be passed to worker threads/);
 	});
 
-	it('rejects the cache option', async () => {
-		await expect(lintTmpDir({ concurrency: 2, cache: true })).rejects.toThrow(
-			/The "cache" option is not supported when the "concurrency" option is enabled/,
+	it('reads the option from the configuration object', async () => {
+		const serial = await lintTmpDir({ formatter: 'json' });
+		const fromConfig = await lintTmpDir({
+			formatter: 'json',
+			config: { ...config, concurrency: 2 },
+		});
+
+		expect(fromConfig.report).toBe(serial.report);
+	});
+
+	it('prefers the option over the configuration object', async () => {
+		const { results } = await lintTmpDir({
+			concurrency: 2,
+			config: { ...config, concurrency: 0 },
+		});
+
+		expect(results).toHaveLength(11);
+	});
+
+	it('rejects an invalid value in the configuration object', async () => {
+		await expect(lintTmpDir({ config: { ...config, concurrency: 0 } })).rejects.toThrow(
+			/expected "auto" or a positive integer/,
 		);
 	});
 
@@ -156,5 +175,92 @@ describe('standalone with concurrency', () => {
 		});
 
 		expect(results[0].warnings).toHaveLength(1);
+	});
+});
+
+describe('standalone with concurrency and cache', () => {
+	const cacheTmpDir = fixturesPath('tmp', 'concurrency-cache');
+	const cacheLocation = path.join(cacheTmpDir, '.stylelintcache');
+
+	const lintCacheTmpDir = (options) =>
+		standalone({
+			files: `${cacheTmpDir}/*.css`,
+			config,
+			cache: true,
+			cacheLocation,
+			concurrency: 2,
+			...options,
+		});
+
+	beforeEach(async () => {
+		await fs.mkdir(cacheTmpDir, { recursive: true });
+
+		await Promise.all(
+			Array.from({ length: 10 }, (_unused, i) =>
+				fs.writeFile(path.join(cacheTmpDir, `clean-${i}.css`), cleanCss),
+			),
+		);
+	});
+
+	afterEach(async () => {
+		await fs.rm(cacheTmpDir, { recursive: true });
+	});
+
+	it('caches linted files and serves them from the cache on the next run', async () => {
+		const cold = await lintCacheTmpDir();
+
+		expect(cold.results).toHaveLength(10);
+		expect(cold.results.every((result) => !result.ignored)).toBe(true);
+
+		const warm = await lintCacheTmpDir();
+
+		expect(warm.results).toHaveLength(10);
+		expect(warm.results.every((result) => result.ignored)).toBe(true);
+		expect(warm.errored).toBe(false);
+	});
+
+	it('lints only the files that changed on a warm run', async () => {
+		await lintCacheTmpDir();
+
+		await fs.writeFile(path.join(cacheTmpDir, 'clean-0.css'), 'b { color: #000; }\n');
+
+		const { results } = await lintCacheTmpDir();
+		const changed = results.filter((result) => !result.ignored);
+
+		expect(changed.map((result) => result.source)).toEqual([path.join(cacheTmpDir, 'clean-0.css')]);
+	});
+
+	it('does not cache files with lint errors or syntax errors', async () => {
+		await fs.writeFile(path.join(cacheTmpDir, 'invalid.css'), warningCss);
+		await fs.writeFile(path.join(cacheTmpDir, 'broken.css'), brokenCss);
+
+		await lintCacheTmpDir();
+
+		const warm = await lintCacheTmpDir();
+		const relinted = warm.results.filter((result) => !result.ignored);
+
+		expect(relinted.map((result) => path.basename(result.source ?? '')).sort()).toEqual([
+			'broken.css',
+			'invalid.css',
+		]);
+		expect(warm.errored).toBe(true);
+	});
+
+	it('returns the same results as a main-thread run with the cache', async () => {
+		await fs.writeFile(path.join(cacheTmpDir, 'invalid.css'), warningCss);
+
+		const serialCacheLocation = path.join(cacheTmpDir, '.stylelintcache-serial');
+
+		await lintCacheTmpDir({ concurrency: undefined, cacheLocation: serialCacheLocation });
+		const serialWarm = await lintCacheTmpDir({
+			concurrency: undefined,
+			cacheLocation: serialCacheLocation,
+			formatter: 'json',
+		});
+
+		await lintCacheTmpDir();
+		const parallelWarm = await lintCacheTmpDir({ formatter: 'json' });
+
+		expect(parallelWarm.report).toBe(serialWarm.report);
 	});
 });

--- a/lib/__tests__/standalone-concurrency.test.mjs
+++ b/lib/__tests__/standalone-concurrency.test.mjs
@@ -127,6 +127,16 @@ describe('standalone with concurrency', () => {
 		expect(parallelError.name).toBe(serialError.name);
 	});
 
+	it('runs workers with an explicit memory limit, so a worker OOM is a catchable error', async () => {
+		const options = { customSyntax: fixturesPath('worker-resource-limits-syntax.mjs') };
+
+		const error = await lintTmpDir({ ...options, concurrency: 2 }).catch((err) => err);
+
+		const limitMb = Number(error.message.match(/maxOldGenerationSizeMb=(\S+)/)?.[1]);
+
+		expect(limitMb).toBeGreaterThan(0);
+	});
+
 	it('rejects options that cannot be passed to worker threads', async () => {
 		await expect(
 			lintTmpDir({

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -93,6 +93,13 @@ const helpText = `
 
         A module name or path to a JS file exporting a PostCSS-compatible syntax.
 
+      --concurrency <count>
+
+        Lint files in parallel using worker threads. The count is either a
+        positive integer or "auto", which sizes the worker pool based on the
+        available CPU cores and the number of files. By default, files are
+        linted in the main thread.
+
       --stdin
 
         Accept stdin input even if it is empty.
@@ -247,6 +254,9 @@ const flags = {
 		type: 'boolean',
 		default: false,
 	},
+	concurrency: {
+		type: 'string',
+	},
 	config: {
 		shortFlag: 'c',
 		type: 'string',
@@ -374,6 +384,7 @@ export default async function main(argv) {
 		cacheLocation,
 		cacheStrategy,
 		computeEditInfo,
+		concurrency,
 		config: configFile,
 		configBasedir,
 		customFormatter,
@@ -546,6 +557,27 @@ export default async function main(argv) {
 
 	if (isBoolean(computeEditInfo)) {
 		options.computeEditInfo = computeEditInfo;
+	}
+
+	if (isString(concurrency)) {
+		if (concurrency === 'auto') {
+			options.concurrency = concurrency;
+		} else {
+			const parsedConcurrency = Number(concurrency);
+
+			if (!Number.isInteger(parsedConcurrency) || parsedConcurrency < 1) {
+				process.stderr.write(
+					`${red(
+						`Error: Invalid value "${concurrency}" for "--concurrency". Expected "auto" or a positive integer.`,
+					)}${EOL}`,
+				);
+				process.exitCode = EXIT_CODE_INVALID_USAGE;
+
+				return;
+			}
+
+			options.concurrency = parsedConcurrency;
+		}
 	}
 
 	// Handle suppress logic - detect both --suppress (all) and --suppress=rule cases

--- a/lib/lintFiles.mjs
+++ b/lib/lintFiles.mjs
@@ -1,0 +1,122 @@
+import createDebug from 'debug';
+const debug = createDebug('stylelint:standalone');
+
+import writeFileAtomic from 'write-file-atomic';
+
+import createPartialStylelintResult from './createPartialStylelintResult.mjs';
+import getConfigForFile from './getConfigForFile.mjs';
+import lintSource from './lintSource.mjs';
+
+/** @import {InternalApi, LinterOptions, LintResult} from 'stylelint' */
+
+/**
+ * Lint each of the given files and return one result per file.
+ *
+ * @param {InternalApi} stylelint
+ * @param {string[]} absoluteFilePaths
+ * @param {object} options
+ * @param {boolean} [options.useCache]
+ * @param {LinterOptions['fix']} [options.fix]
+ * @param {AbortSignal} [options.abortSignal]
+ * @returns {Promise<LintResult[]>}
+ */
+export default function lintFiles(
+	stylelint,
+	absoluteFilePaths,
+	{ useCache = false, fix, abortSignal } = {},
+) {
+	const getStylelintResults = absoluteFilePaths.map(async (absoluteFilepath) => {
+		debug(`Processing ${absoluteFilepath}`);
+
+		try {
+			if (abortSignal?.aborted) {
+				throw abortSignal.reason;
+			}
+
+			const postcssResult = await lintSource(stylelint, {
+				filePath: absoluteFilepath,
+				cache: useCache,
+				abortSignal,
+			});
+
+			if (abortSignal?.aborted) {
+				throw abortSignal.reason;
+			}
+
+			if (
+				(postcssResult.stylelint.stylelintError || postcssResult.stylelint.stylelintWarning) &&
+				useCache
+			) {
+				debug(`${absoluteFilepath} contains linting errors and will not be cached.`);
+				stylelint._fileCache.removeEntry(absoluteFilepath);
+			}
+
+			/**
+			 * If we're fixing, save the file with changed code
+			 */
+			if (postcssResult.root && postcssResult.opts && !postcssResult.stylelint.ignored && fix) {
+				const fixedCss = postcssResult.root.toString(postcssResult.opts.syntax);
+
+				if (
+					postcssResult.root &&
+					postcssResult.root.source &&
+					postcssResult.root.source.input.css !== fixedCss
+				) {
+					await writeFileAtomic(absoluteFilepath, fixedCss);
+					postcssResult.stylelint.autofixed = true;
+				}
+			}
+
+			const stylelintResult = createPartialStylelintResult(postcssResult);
+
+			await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
+
+			return stylelintResult;
+		} catch (error) {
+			// On any error, we should not cache the lint result
+			stylelint._fileCache.removeEntry(absoluteFilepath);
+
+			const stylelintResult = handleError(error);
+
+			await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
+
+			return stylelintResult;
+		}
+	});
+
+	return Promise.all(getStylelintResults);
+}
+
+/**
+ * @import {CssSyntaxError} from 'stylelint'
+ *
+ * @param {unknown} error
+ * @returns {LintResult}
+ */
+export function handleError(error) {
+	if (error instanceof Error && error.name === 'CssSyntaxError') {
+		return createPartialStylelintResult(undefined, /** @type {CssSyntaxError} */ (error));
+	}
+
+	throw error;
+}
+
+/**
+ * @param {InternalApi} stylelint
+ * @param {LintResult} stylelintResult
+ * @param {string} [filePath]
+ * @returns {Promise<void>}
+ */
+export async function postProcessStylelintResult(stylelint, stylelintResult, filePath) {
+	const configForFile = await getConfigForFile({ stylelint, searchPath: filePath, filePath });
+
+	const config = configForFile === null ? {} : configForFile.config;
+
+	if (!config._processorFunctions) {
+		return;
+	}
+
+	for (const postprocess of config._processorFunctions.values()) {
+		postprocess?.(stylelintResult, stylelintResult._postcssResult?.root);
+	}
+}

--- a/lib/lintFilesInWorkers.mjs
+++ b/lib/lintFilesInWorkers.mjs
@@ -1,5 +1,6 @@
 import { Worker } from 'node:worker_threads';
 import { availableParallelism } from 'node:os';
+import { getHeapStatistics } from 'node:v8';
 
 /** @import {LinterOptions, LintResult} from 'stylelint' */
 
@@ -122,6 +123,19 @@ export default function lintFilesInWorkers(absoluteFilePaths, options, workerCou
 		Math.min(MAX_FILES_PER_TASK, Math.ceil(absoluteFilePaths.length / (workerCount * 4))),
 	);
 
+	// Without an explicit limit, a worker that exhausts its heap is a fatal V8
+	// error that aborts the whole process, report and all; with one, Node.js
+	// instead terminates just that worker with a catchable
+	// ERR_WORKER_OUT_OF_MEMORY as its old generation approaches the cap. The
+	// cap sits below the main thread's total heap limit (which reflects
+	// `--max-old-space-size`) so that check fires while the total still has
+	// headroom; a single allocation larger than the headroom can still hit the
+	// fatal path.
+	const heapLimitMb = getHeapStatistics().heap_size_limit / 1024 / 1024;
+	const resourceLimits = {
+		maxOldGenerationSizeMb: Math.max(1, Math.floor(heapLimitMb - 128)),
+	};
+
 	/** @type {Array<{ offset: number, files: string[] }>} */
 	const tasks = [];
 
@@ -164,7 +178,7 @@ export default function lintFilesInWorkers(absoluteFilePaths, options, workerCou
 		abortSignal?.addEventListener('abort', () => fail(abortSignal.reason), { once: true });
 
 		const spawn = () => {
-			const worker = new Worker(workerURL, { workerData: { options } });
+			const worker = new Worker(workerURL, { workerData: { options }, resourceLimits });
 
 			workers.add(worker);
 

--- a/lib/lintFilesInWorkers.mjs
+++ b/lib/lintFilesInWorkers.mjs
@@ -1,0 +1,224 @@
+import { Worker } from 'node:worker_threads';
+import { availableParallelism } from 'node:os';
+
+/** @import {LinterOptions, LintResult} from 'stylelint' */
+
+/**
+ * The lint options forwarded to every worker thread. This is an explicit
+ * subset of the linter options: anything resolved in the main thread (globs,
+ * formatter, `maxWarnings`, cache, suppressions) is excluded.
+ *
+ * @typedef {Pick<LinterOptions,
+ *   'config' | 'configFile' | 'configBasedir' | 'customSyntax' | 'cwd' |
+ *   'disableDefaultIgnores' | 'fix' | 'computeEditInfo' | 'ignoreDisables' |
+ *   'ignorePath' | 'ignorePattern' | 'quiet' | 'quietDeprecationWarnings' |
+ *   'reportDescriptionlessDisables' | 'reportInvalidScopeDisables' |
+ *   'reportNeedlessDisables' | 'reportUnscopedDisables' | 'validate'
+ * >} WorkerOptions
+ *
+ * @typedef {{ files: string[] }} LintTask
+ *
+ * @typedef {{ name: string, message: string, stack: string | undefined, properties: Record<string, unknown> }} TransferableError
+ *
+ * @typedef {Omit<LintResult, '_postcssResult'> & {
+ *   _postcssResult?: {
+ *     stylelint: Pick<NonNullable<LintResult['_postcssResult']>['stylelint'],
+ *       'ruleMetadata' | 'fixersData' | 'stylelintError' | 'stylelintWarning'>
+ *   }
+ * }} TransferableLintResult
+ *
+ * @typedef {{ results: TransferableLintResult[], error?: never } | { error: TransferableError, results?: never }} LintTaskResponse
+ */
+
+/**
+ * Cap on the number of files a worker lints per task. Every file in a task is
+ * opened concurrently, so this bounds open file descriptors; it is also the
+ * pull-scheduling granularity that keeps workers evenly loaded when file
+ * sizes are skewed.
+ */
+const MAX_FILES_PER_TASK = 64;
+
+/**
+ * With `concurrency: 'auto'`, spawn at most one worker per this many files so
+ * that small runs do not pay worker startup cost for little gain. The shape of
+ * the heuristic matches ESLint's `concurrency: "auto"`; the constant is higher
+ * because linting a file tends to be cheaper in Stylelint.
+ */
+const AUTO_FILES_PER_WORKER = 128;
+
+const workerURL = new URL('./lintWorker.mjs', import.meta.url);
+
+/**
+ * @param {LinterOptions['concurrency']} concurrency
+ * @returns {void}
+ */
+export function validateConcurrency(concurrency) {
+	if (concurrency === undefined || concurrency === 'auto') {
+		return;
+	}
+
+	if (typeof concurrency === 'number' && Number.isInteger(concurrency) && concurrency >= 1) {
+		return;
+	}
+
+	throw new Error(
+		`Invalid option value "${concurrency}" for "concurrency": expected "auto" or a positive integer`,
+	);
+}
+
+/**
+ * Resolve the `concurrency` option to a worker count for the given number of
+ * files. A result of `1` means "lint in the main thread, as without the
+ * option".
+ *
+ * @param {LinterOptions['concurrency']} concurrency
+ * @param {number} fileCount
+ * @returns {number}
+ */
+export function resolveWorkerCount(concurrency, fileCount) {
+	if (concurrency === undefined) {
+		return 1;
+	}
+
+	if (concurrency === 'auto') {
+		// Cap at half the cores, leaving room for the main thread and the rest
+		// of the system; a result of 1 means the startup cost of a lone worker
+		// cannot pay off, so lint in the main thread instead.
+		const maxWorkers = Math.max(1, Math.floor(availableParallelism() / 2));
+		const workerCount = Math.min(maxWorkers, Math.ceil(fileCount / AUTO_FILES_PER_WORKER));
+
+		return workerCount > 1 ? workerCount : 1;
+	}
+
+	return Math.min(concurrency, Math.max(fileCount, 1));
+}
+
+/**
+ * Lint files across a pool of worker threads that pull tasks from a shared
+ * queue. Results come back in the order of `absoluteFilePaths`, matching what
+ * linting in the main thread produces.
+ *
+ * @param {string[]} absoluteFilePaths
+ * @param {WorkerOptions} options
+ * @param {number} workerCount
+ * @param {AbortSignal} [abortSignal]
+ * @returns {Promise<LintResult[]>}
+ */
+export default function lintFilesInWorkers(absoluteFilePaths, options, workerCount, abortSignal) {
+	try {
+		structuredClone(options);
+	} catch {
+		throw new Error(
+			'The "concurrency" option requires options that can be passed to worker threads. ' +
+				'For example, use "configFile" instead of a "config" object containing functions',
+		);
+	}
+
+	// Aim for several tasks per worker so that a worker drawing large files
+	// does not become the long pole, while capping a task's file count to
+	// bound concurrently open file descriptors.
+	const filesPerTask = Math.max(
+		1,
+		Math.min(MAX_FILES_PER_TASK, Math.ceil(absoluteFilePaths.length / (workerCount * 4))),
+	);
+
+	/** @type {Array<{ offset: number, files: string[] }>} */
+	const tasks = [];
+
+	for (let offset = 0; offset < absoluteFilePaths.length; offset += filesPerTask) {
+		tasks.push({ offset, files: absoluteFilePaths.slice(offset, offset + filesPerTask) });
+	}
+
+	return new Promise((resolve, reject) => {
+		/** @type {LintResult[]} */
+		const results = new Array(absoluteFilePaths.length);
+		/** @type {Set<Worker>} */
+		const workers = new Set();
+		let nextTask = 0;
+		let completedTasks = 0;
+		let settled = false;
+
+		const terminateAll = () => Promise.all([...workers].map((worker) => worker.terminate()));
+
+		/** @param {unknown} error */
+		const fail = (error) => {
+			if (settled) return;
+
+			settled = true;
+			void terminateAll().then(() => reject(error));
+		};
+
+		const finish = () => {
+			if (settled) return;
+
+			settled = true;
+			void terminateAll().then(() => resolve(results));
+		};
+
+		if (abortSignal?.aborted) {
+			reject(abortSignal.reason);
+
+			return;
+		}
+
+		abortSignal?.addEventListener('abort', () => fail(abortSignal.reason), { once: true });
+
+		const spawn = () => {
+			const worker = new Worker(workerURL, { workerData: { options } });
+
+			workers.add(worker);
+
+			/** @type {{ offset: number, files: string[] } | undefined} */
+			let currentTask;
+
+			const assign = () => {
+				const task = tasks[nextTask];
+
+				if (settled || !task) return;
+
+				currentTask = task;
+				nextTask += 1;
+				worker.postMessage(/** @type {LintTask} */ ({ files: task.files }));
+			};
+
+			worker.on('message', (/** @type {LintTaskResponse} */ response) => {
+				if (response.error) {
+					const { name, message, stack, properties } = response.error;
+					const error = Object.assign(new Error(message), properties, { name, stack });
+
+					fail(error);
+
+					return;
+				}
+
+				const task = currentTask;
+
+				if (!task) return;
+
+				response.results.forEach((result, index) => {
+					results[task.offset + index] = /** @type {LintResult} */ (
+						/** @type {unknown} */ (result)
+					);
+				});
+
+				completedTasks += 1;
+
+				if (completedTasks === tasks.length) {
+					finish();
+				} else {
+					assign();
+				}
+			});
+
+			worker.on('error', fail);
+
+			assign();
+		};
+
+		const poolSize = Math.min(workerCount, tasks.length);
+
+		for (let index = 0; index < poolSize; index += 1) {
+			spawn();
+		}
+	});
+}

--- a/lib/lintWorker.mjs
+++ b/lib/lintWorker.mjs
@@ -1,0 +1,88 @@
+import { parentPort, workerData } from 'node:worker_threads';
+
+import createStylelint from './createStylelint.mjs';
+import lintFiles from './lintFiles.mjs';
+
+/** @import {LintResult} from 'stylelint' */
+/** @import {LintTask, LintTaskResponse, TransferableError, TransferableLintResult, WorkerOptions} from './lintFilesInWorkers.mjs' */
+
+if (!parentPort) {
+	throw new Error('This module must be run in a worker thread');
+}
+
+const port = parentPort;
+
+const { options } = /** @type {{ options: WorkerOptions }} */ (workerData);
+const stylelint = createStylelint(options);
+
+port.on('message', (/** @type {LintTask} */ { files }) => {
+	lintFiles(stylelint, files, { useCache: false, fix: options.fix })
+		.then((results) => {
+			port.postMessage(
+				/** @type {LintTaskResponse} */ ({ results: results.map(toTransferableResult) }),
+			);
+		})
+		.catch((error) => {
+			port.postMessage(/** @type {LintTaskResponse} */ ({ error: serializeError(error) }));
+		});
+});
+
+/**
+ * Make a lint result transferable via `postMessage()`.
+ *
+ * A full lint result cannot cross a thread boundary: `_postcssResult` holds the
+ * PostCSS AST and resolved config (which may contain plugin functions), and
+ * parse errors are PostCSS warnings that reference AST nodes. Everything the
+ * main thread consumes afterwards is retained: plain warning objects, and the
+ * `_postcssResult.stylelint` fields read by `prepareReturnValue()`
+ * (`ruleMetadata`) and the verbose formatter (`fixersData`).
+ *
+ * @param {LintResult} result
+ * @returns {TransferableLintResult}
+ */
+function toTransferableResult(result) {
+	// A shallow copy with values replaced in place, rather than a rest spread
+	// with properties re-added, so that the key order (and thereby JSON
+	// formatter output) stays identical to a main-thread result.
+	const transferable = /** @type {TransferableLintResult} */ ({ ...result });
+
+	transferable.parseErrors = result.parseErrors.map(
+		({ line, column, endLine, endColumn, text, stylelintType }) =>
+			/** @type {LintResult['parseErrors'][0]} */ (
+				/** @type {unknown} */ ({ line, column, endLine, endColumn, text, stylelintType })
+			),
+	);
+
+	if (result._postcssResult) {
+		transferable._postcssResult = {
+			stylelint: {
+				ruleMetadata: result._postcssResult.stylelint.ruleMetadata,
+				fixersData: result._postcssResult.stylelint.fixersData,
+				stylelintError: result._postcssResult.stylelint.stylelintError,
+				stylelintWarning: result._postcssResult.stylelint.stylelintWarning,
+			},
+		};
+	}
+
+	return transferable;
+}
+
+/**
+ * `postMessage()` clones only an error's standard properties, so carry the
+ * custom ones (e.g. `code` on `ConfigurationError`) explicitly.
+ *
+ * @param {unknown} error
+ * @returns {TransferableError}
+ */
+function serializeError(error) {
+	if (!(error instanceof Error)) {
+		return { name: 'Error', message: String(error), stack: undefined, properties: {} };
+	}
+
+	return {
+		name: error.name,
+		message: error.message,
+		stack: error.stack,
+		properties: { ...error },
+	};
+}

--- a/lib/lintWorker.mjs
+++ b/lib/lintWorker.mjs
@@ -1,4 +1,5 @@
 import { parentPort, workerData } from 'node:worker_threads';
+import { types } from 'node:util';
 
 import createStylelint from './createStylelint.mjs';
 import lintFiles from './lintFiles.mjs';
@@ -75,7 +76,9 @@ function toTransferableResult(result) {
  * @returns {TransferableError}
  */
 function serializeError(error) {
-	if (!(error instanceof Error)) {
+	// `isNativeError` instead of `instanceof Error` so that an error created in
+	// another realm (e.g. a built-in module) is still serialized with its stack.
+	if (!types.isNativeError(error)) {
 		return { name: 'Error', message: String(error), stack: undefined, properties: {} };
 	}
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -8,21 +8,25 @@ import fastGlob from 'fast-glob';
 import { globby } from 'globby';
 import micromatch from 'micromatch';
 import normalizePath from 'normalize-path';
-import writeFileAtomic from 'write-file-atomic';
 
 import {
 	AllFilesIgnoredError,
+	ConfigurationError,
 	NoFilesFoundError,
 	SuppressionFileNotFoundError,
 } from './utils/errors.mjs';
 import { assertString, isString } from './utils/validateTypes.mjs';
+import lintFiles, { handleError, postProcessStylelintResult } from './lintFiles.mjs';
+import lintFilesInWorkers, {
+	resolveWorkerCount,
+	validateConcurrency,
+} from './lintFilesInWorkers.mjs';
 import { DEFAULT_SUPPRESSION_FILENAME } from './constants.mjs';
 import { SuppressionsService } from './utils/suppressionsService.mjs';
 import createPartialStylelintResult from './createPartialStylelintResult.mjs';
 import createStylelint from './createStylelint.mjs';
 import { emitExperimentalWarning } from './utils/emitWarning.mjs';
 import filterFilePaths from './utils/filterFilePaths.mjs';
-import getConfigForFile from './getConfigForFile.mjs';
 import getFileIgnorer from './utils/getFileIgnorer.mjs';
 import getFormatter from './utils/getFormatter.mjs';
 import lintSource from './lintSource.mjs';
@@ -35,8 +39,6 @@ import toPath from './utils/toPath.mjs';
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 
-/** @import {InternalApi, LintResult} from 'stylelint' */
-
 /**
  * @type {import('stylelint').PublicApi['lint']}
  */
@@ -48,6 +50,7 @@ export default async function standalone({
 	cacheStrategy,
 	code,
 	codeFilename,
+	concurrency,
 	config,
 	configBasedir,
 	configFile,
@@ -85,6 +88,8 @@ export default async function standalone({
 			new Error('You must pass stylelint a `files` glob or a `code` string, though not both'),
 		);
 	}
+
+	validateConcurrency(concurrency);
 
 	// The ignorer will be used to filter file paths after the glob is checked,
 	// before any files are actually read
@@ -255,66 +260,49 @@ export default async function standalone({
 			isAbsolute(filePath) ? normalize(filePath) : join(globCWD, filePath),
 		);
 
-		const getStylelintResults = absoluteFilePaths.map(async (absoluteFilepath) => {
-			debug(`Processing ${absoluteFilepath}`);
+		const workerCount = resolveWorkerCount(concurrency, absoluteFilePaths.length);
 
-			try {
-				if (abortSignal?.aborted) {
-					throw abortSignal.reason;
-				}
-
-				const postcssResult = await lintSource(stylelint, {
-					filePath: absoluteFilepath,
-					cache: useCache,
-					abortSignal,
-				});
-
-				if (abortSignal?.aborted) {
-					throw abortSignal.reason;
-				}
-
-				if (
-					(postcssResult.stylelint.stylelintError || postcssResult.stylelint.stylelintWarning) &&
-					useCache
-				) {
-					debug(`${absoluteFilepath} contains linting errors and will not be cached.`);
-					stylelint._fileCache.removeEntry(absoluteFilepath);
-				}
-
-				/**
-				 * If we're fixing, save the file with changed code
-				 */
-				if (postcssResult.root && postcssResult.opts && !postcssResult.stylelint.ignored && fix) {
-					const fixedCss = postcssResult.root.toString(postcssResult.opts.syntax);
-
-					if (
-						postcssResult.root &&
-						postcssResult.root.source &&
-						postcssResult.root.source.input.css !== fixedCss
-					) {
-						await writeFileAtomic(absoluteFilepath, fixedCss);
-						postcssResult.stylelint.autofixed = true;
-					}
-				}
-
-				const stylelintResult = createPartialStylelintResult(postcssResult);
-
-				await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
-
-				return stylelintResult;
-			} catch (error) {
-				// On any error, we should not cache the lint result
-				stylelint._fileCache.removeEntry(absoluteFilepath);
-
-				const stylelintResult = handleError(error);
-
-				await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
-
-				return stylelintResult;
+		if (workerCount > 1) {
+			if (useCache) {
+				throw new ConfigurationError(
+					'The "cache" option is not supported when the "concurrency" option is enabled. Remove one of the two options',
+				);
 			}
-		});
 
-		stylelintResults = await Promise.all(getStylelintResults);
+			const workerOptions = {
+				config,
+				configFile,
+				configBasedir,
+				customSyntax,
+				cwd,
+				disableDefaultIgnores,
+				fix,
+				computeEditInfo,
+				ignoreDisables,
+				ignorePath,
+				ignorePattern,
+				quiet,
+				quietDeprecationWarnings,
+				reportDescriptionlessDisables,
+				reportInvalidScopeDisables,
+				reportNeedlessDisables,
+				reportUnscopedDisables,
+				validate,
+			};
+
+			stylelintResults = await lintFilesInWorkers(
+				absoluteFilePaths,
+				workerOptions,
+				workerCount,
+				abortSignal,
+			);
+		} else {
+			stylelintResults = await lintFiles(stylelint, absoluteFilePaths, {
+				useCache,
+				fix,
+				abortSignal,
+			});
+		}
 	} else if (await resolveOptionValue({ stylelint, name: 'allowEmptyInput', default: false })) {
 		stylelintResults = await Promise.all([]);
 	} else if (filePathsLengthBeforeIgnore) {
@@ -377,38 +365,4 @@ export default async function standalone({
 	debug(`Linting complete in ${Date.now() - startTime}ms`);
 
 	return result;
-}
-
-/**
- * @import {CssSyntaxError} from 'stylelint'
- *
- * @param {unknown} error
- * @returns {LintResult}
- */
-function handleError(error) {
-	if (error instanceof Error && error.name === 'CssSyntaxError') {
-		return createPartialStylelintResult(undefined, /** @type {CssSyntaxError} */ (error));
-	}
-
-	throw error;
-}
-
-/**
- * @param {InternalApi} stylelint
- * @param {LintResult} stylelintResult
- * @param {string} [filePath]
- * @returns {Promise<void>}
- */
-async function postProcessStylelintResult(stylelint, stylelintResult, filePath) {
-	const configForFile = await getConfigForFile({ stylelint, searchPath: filePath, filePath });
-
-	const config = configForFile === null ? {} : configForFile.config;
-
-	if (!config._processorFunctions) {
-		return;
-	}
-
-	for (const postprocess of config._processorFunctions.values()) {
-		postprocess?.(stylelintResult, stylelintResult._postcssResult?.root);
-	}
 }

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -11,7 +11,6 @@ import normalizePath from 'normalize-path';
 
 import {
 	AllFilesIgnoredError,
-	ConfigurationError,
 	NoFilesFoundError,
 	SuppressionFileNotFoundError,
 } from './utils/errors.mjs';
@@ -27,6 +26,7 @@ import createPartialStylelintResult from './createPartialStylelintResult.mjs';
 import createStylelint from './createStylelint.mjs';
 import { emitExperimentalWarning } from './utils/emitWarning.mjs';
 import filterFilePaths from './utils/filterFilePaths.mjs';
+import getConfigForFile from './getConfigForFile.mjs';
 import getFileIgnorer from './utils/getFileIgnorer.mjs';
 import getFormatter from './utils/getFormatter.mjs';
 import lintSource from './lintSource.mjs';
@@ -38,6 +38,8 @@ import resolveOptionValue from './utils/resolveOptionValue.mjs';
 import toPath from './utils/toPath.mjs';
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
+
+/** @import {LintResult} from 'stylelint' */
 
 /**
  * @type {import('stylelint').PublicApi['lint']}
@@ -107,6 +109,7 @@ export default async function standalone({
 		cache,
 		cacheLocation,
 		cacheStrategy,
+		concurrency,
 		config,
 		configFile,
 		configBasedir,
@@ -260,15 +263,54 @@ export default async function standalone({
 			isAbsolute(filePath) ? normalize(filePath) : join(globCWD, filePath),
 		);
 
-		const workerCount = resolveWorkerCount(concurrency, absoluteFilePaths.length);
+		const resolvedConcurrency = await resolveOptionValue({
+			stylelint,
+			name: 'concurrency',
+			default: concurrency,
+		});
+
+		validateConcurrency(resolvedConcurrency);
+
+		const useWorkers = resolvedConcurrency !== undefined && resolvedConcurrency !== 1;
+
+		/** Files to lint in worker threads; with the cache enabled, only the files that changed. */
+		let workerFiles = absoluteFilePaths;
+		/** Files whose previous clean result is served from the cache in the main thread. */
+		/** @type {string[]} */
+		const cachedFiles = [];
+
+		if (useWorkers && useCache) {
+			// Mirror the sequence `lintSource()` runs per file: the config hash is
+			// locked to the first file's config, and `hasFileChanged()` records the
+			// file's current descriptor as a side effect, so a changed file that
+			// lints cleanly ends up cached on `reconcile()`.
+			const configForFile = await getConfigForFile({
+				stylelint,
+				searchPath: absoluteFilePaths[0],
+				filePath: absoluteFilePaths[0],
+			});
+
+			stylelint._fileCache.calcHashOfConfig(configForFile?.config ?? {});
+
+			workerFiles = [];
+
+			for (const absoluteFilepath of absoluteFilePaths) {
+				if (stylelint._fileCache.hasFileChanged(absoluteFilepath)) {
+					workerFiles.push(absoluteFilepath);
+				} else {
+					cachedFiles.push(absoluteFilepath);
+				}
+			}
+		}
+
+		// Sizing on the files that actually need linting means a warm-cache run
+		// stays in the main thread instead of spawning workers for a handful of
+		// changed files.
+		const workerCount = useWorkers
+			? resolveWorkerCount(resolvedConcurrency, workerFiles.length)
+			: 1;
 
 		if (workerCount > 1) {
-			if (useCache) {
-				throw new ConfigurationError(
-					'The "cache" option is not supported when the "concurrency" option is enabled. Remove one of the two options',
-				);
-			}
-
 			const workerOptions = {
 				config,
 				configFile,
@@ -290,12 +332,52 @@ export default async function standalone({
 				validate,
 			};
 
-			stylelintResults = await lintFilesInWorkers(
-				absoluteFilePaths,
+			const workerResults = await lintFilesInWorkers(
+				workerFiles,
 				workerOptions,
 				workerCount,
 				abortSignal,
 			);
+
+			if (useCache) {
+				workerResults.forEach((result, index) => {
+					// Mirror the main-thread path: don't cache files with lint
+					// errors or warnings. A result without `_postcssResult` is a
+					// CSS syntax error.
+					const postcssResult = result._postcssResult?.stylelint;
+
+					if (!postcssResult || postcssResult.stylelintError || postcssResult.stylelintWarning) {
+						debug(`${workerFiles[index]} contains linting errors and will not be cached.`);
+						stylelint._fileCache.removeEntry(/** @type {string} */ (workerFiles[index]));
+					}
+				});
+			}
+
+			if (cachedFiles.length > 0) {
+				// Serving a cache hit is a short-circuit in `lintSource()` (no file
+				// read, no parse), so these run in the main thread.
+				const cachedResults = await lintFiles(stylelint, cachedFiles, {
+					useCache,
+					fix,
+					abortSignal,
+				});
+
+				/** @type {Map<string, LintResult>} */
+				const resultByFilePath = new Map();
+
+				workerFiles.forEach((file, index) => {
+					resultByFilePath.set(file, /** @type {LintResult} */ (workerResults[index]));
+				});
+				cachedFiles.forEach((file, index) => {
+					resultByFilePath.set(file, /** @type {LintResult} */ (cachedResults[index]));
+				});
+
+				stylelintResults = absoluteFilePaths.map(
+					(file) => /** @type {LintResult} */ (resultByFilePath.get(file)),
+				);
+			} else {
+				stylelintResults = workerResults;
+			}
 		} else {
 			stylelintResults = await lintFiles(stylelint, absoluteFilePaths, {
 				useCache,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1187,6 +1187,15 @@ declare namespace stylelint {
 		 * current working directory.
 		 */
 		cwd?: string;
+		/**
+		 * The number of worker threads used to lint files in parallel, or
+		 * `'auto'` to size the pool based on the available CPU cores and the
+		 * number of files. By default, files are linted in the main thread.
+		 *
+		 * Only applies when linting `files`; it is ignored when linting
+		 * `code`. Cannot be combined with `cache` yet.
+		 */
+		concurrency?: number | 'auto';
 		ignoreDisables?: boolean;
 		ignorePath?: OneOrMany<string>;
 		ignorePattern?: string[];

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -274,6 +274,16 @@ declare namespace stylelint {
 		 */
 		cache?: boolean;
 		/**
+		 * The number of worker threads used to lint files in parallel, or
+		 * `'auto'` to size the pool based on the available CPU cores and the
+		 * number of files. By default, files are linted in the main thread.
+		 *
+		 * Should not be overridden on a per-file basis
+		 *
+		 * @see [concurrency](https://stylelint.io/user-guide/configure#concurrency)
+		 */
+		concurrency?: number | 'auto';
+		/**
 		 * If true, automatically fix, where possible, problems reported by rules.
 		 *
 		 * Should not be overridden on a per-file basis
@@ -1193,7 +1203,8 @@ declare namespace stylelint {
 		 * number of files. By default, files are linted in the main thread.
 		 *
 		 * Only applies when linting `files`; it is ignored when linting
-		 * `code`. Cannot be combined with `cache` yet.
+		 * `code`. With `cache` enabled, only the files that changed are linted
+		 * in workers.
 		 */
 		concurrency?: number | 'auto';
 		ignoreDisables?: boolean;


### PR DESCRIPTION
> [!NOTE]
> Design discussion: #9424.

Closes #9424

Adds an opt-in `concurrency` option (`--concurrency <count|auto>` on the CLI, `concurrency` in the Node.js API) that lints files in parallel across `worker_threads`.

## Why

- Stylelint lints every file in a single thread today. On large codebases the lint pass takes minutes in CI while all other cores idle.
- Ecosystem workarounds exist to get parallelism by wrapping Stylelint (`jest-runner-stylelint`, hand-rolled worker pools that shard the file list). Each wrapper re-implements scheduling and output merging, and can drift from what plain `stylelint` reports. Supporting this in core gives everyone the speedup with identical results and no wrapper to maintain.
- Prior art: ESLint shipped the same shape of option (`--concurrency <int|auto|off>`) in v9.34.
- It serves the [vision](https://stylelint.io/about/vision/)'s "Performant" principle: provide a fast linter and the means to improve its performance.

## What

- **Default behavior is unchanged.** Without the option (or with `concurrency: 1`), linting runs in the main thread exactly as before.
- With `concurrency: N`, a pool of N workers pulls tasks (up to 64 files each) from a shared queue, so workers stay evenly loaded when file costs are skewed. Results are merged in input order; the formatter, `maxWarnings`, and suppressions still run once in the main thread.
- `concurrency: 'auto'` resolves to `ceil(files / 128)` workers, capped at half the available cores, and falls back to main-thread linting for small runs, so `auto` never regresses them. This mirrors ESLint's `auto` heuristic (their divisor is 50; Stylelint's per-file work tends to be cheaper).
- The option is configurable in the configuration object as well as via the CLI flag, with the flag taking precedence, per the [direction discussed below](#issuecomment-5152989046).
- Works with `cache`: the main thread serves cache hits and only the files that changed go to workers; `auto` sizes the pool on the changed-file count (like ESLint, so a warm run with a handful of changed files stays in the main thread), and files with errors are evicted exactly like the main-thread path.
- Output parity: the per-file results and the final report are byte-identical to a main-thread run, including CSS syntax errors, `--fix` writes, exit codes, and `ruleMetadata`.
- Guardrails:
  - Options that cannot cross a thread boundary (e.g. a `config` object containing plugin functions) produce a clear error suggesting `configFile`.
  - The option only applies to `files`; it is ignored for `code`/stdin.
  - Workers run with an explicit memory limit mirroring the main thread's, so a worker that runs out of memory fails the run with a regular error instead of a fatal V8 abort that kills the process without a report.

## Impact

Corpora generated with the repo's own benchmark harness (`scripts/benchmarking`), Apple M3 Max (14 cores), Node.js 24, median of 5 CLI runs after 2 warmups, end-to-end wall time:

| Corpus | Main thread | `--concurrency auto` |
| --- | --- | --- |
| medium (100 files, ~1 kB each) | 0.27s | 0.28s (auto stays in the main thread) |
| xlarge (1,000 files, ~1 kB each) | 1.26s | 1.03s (**1.2x**) |
| heavy (500 files, ~13 kB each: the `large` workspace with each file's content repeated 20x) | 4.76s | 1.73s (**2.8x**; 1.57s / **3.0x** with `--concurrency 8`) |

And on a real-world corpus, a large CSS-in-JS monorepo where TypeScript/JavaScript files are linted through a custom syntax for css template literals, with a ~50-rule config including custom plugin rules:

| Corpus | Main thread | `--concurrency auto` |
| --- | --- | --- |
| CSS-in-JS monorepo slice (31,608 files) | 65.8s | 22.4s (**2.9x**, 7 workers) |

On that corpus `auto`'s half-the-cores cap also beat a full-width pool: 14 workers came in at 24.4s, slightly slower than the 7 `auto` picked.

Cache interplay, measured on the full corpus (153,054 files, 5 runs per row, medians):

| Run | `--concurrency auto` |
| --- | --- |
| Cold, no cache | 75.8s |
| Cold, `--cache` (cache cleared before each run) | 71.9s (populating the cache costs nothing measurable) |
| Warm, `--cache` | 41.9s (152,936 files served from the cache; only the 118 files with problems re-linted) |

A warm parallel run's output matched a warm main-thread run per file, and `auto` sized itself on the changed-file count, so the warm runs stayed in the main thread instead of spawning workers for a handful of files.

- Every run's output was verified identical per file against the main-thread run (JSON formatter; 272,403 warnings on the heavy corpus).
- Tiny-file corpora barely gain because worker startup dominates, which is exactly why the option is off by default and why `auto` sizes down to the main thread.
- The gain grows with per-file cost (realistic stylesheet sizes, expensive rules, custom syntaxes), where the single thread is the bottleneck.
- A side observation from the monorepo runs: the main-thread path opens every file of a run concurrently, so a ~150k-file invocation dies with `EMFILE` once it hits macOS's per-process descriptor cap (`kern.maxfilesperproc`, 138,240 by default). The worker path bounds this by construction, since a worker holds at most one 64-file task at a time.

## How

- `lib/lintFiles.mjs`: the existing per-file loop extracted verbatim from `standalone.mjs` (plus its `handleError`/`postProcessStylelintResult` helpers), used unchanged by both the main-thread path and workers.
- `lib/lintWorker.mjs`: worker entry point; creates its own Stylelint instance from the forwarded options (so config resolution, plugins, and custom syntaxes load per worker) and returns transferable results. A slim `_postcssResult` stub keeps the two fields consumers read after linting (`ruleMetadata` for `prepareReturnValue`, `fixersData` for the verbose formatter); parse errors are mapped to plain objects because PostCSS warnings reference AST nodes.
- `lib/lintFilesInWorkers.mjs`: option validation, `auto` resolution, and the pull-based worker pool.
- Worker options are an explicit allowlist of the linting-relevant options; anything resolved in the main thread (globs, formatter, `maxWarnings`, cache, suppressions) is excluded by construction.

## Testing

- New `lib/__tests__/standalone-concurrency.test.mjs`: output parity with the main thread (byte-equal reports for the JSON and string formatters), CSS syntax errors, `--fix` writing to disk, `maxWarnings`, `auto`, worker error propagation matching main-thread errors, non-transferable options, invalid-value validation, the configuration-object surface (incl. flag precedence), and cache behavior (hits served from cache, only changed files re-linted, errored files evicted, warm-run parity with the main thread).
- New CLI tests: flag parsing, a worker-thread lint run via the CLI, and invalid-usage exit code for bad `--concurrency` values.
- Full suite passes: 11,109 tests, plus `lint:types`, ESLint, and Prettier.
- Verified locally on Node.js 20.20.2, 22.21.1, 24.13.0, and 26.5.1 (the CI matrix): lint and the full test suite pass on all four.

## Open questions

- ~~Should `cache` support follow in this PR or a separate one?~~ Landed in this PR per review feedback.
- ~~Is CLI + Node.js API the right surface for v1, or should the option also be allowed in the configuration object?~~ Now configuration object + CLI flag, with the flag taking precedence, per review feedback.
- Naming and `auto` heuristics are easy to change if you'd like a different shape.

