### PR TITLE
Document "ready to implement" label in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@ To help out, you can:
 
 Not only will you help Stylelint thrive, but you may learn a thing or two — about CSS, PostCSS, Node.js, unit testing, open-source software, and more. We want to encourage contributions! If you want to participate but couldn't, please [give us feedback](https://github.com/stylelint/stylelint/issues/new) about what we could do better.
 
+> [!IMPORTANT]
+> Create pull requests for issues opened by others only if the issue is labeled `status: ready to implement`.
+
 ## Code contributions
 
 To start coding, you'll need the:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

On a couple of occasions, shortly after someone opened an issue, someone else opened a corresponding PR (I assume using automated tooling) before we'd had a chance to triage it and identify what needs to be done. 

This PR adds a NOTE to qualify the "get involved in any open [issue](https://github.com/stylelint/stylelint/issues) or [pull request](https://github.com/stylelint/stylelint/pulls)" bullet in the same section.
