### PR TITLE
Fix `property-layout-mappings` false negatives for physical shorthand properties

### DIFF
--- a/.changeset/tidy-geckos-shout.md
+++ b/.changeset/tidy-geckos-shout.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `property-layout-mappings` false negatives for physical shorthand properties

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -1117,6 +1117,23 @@ export const previouslyKnownPrefixedProperties = new Set([
 	'-webkit-wrap',
 ]);
 
+/**
+ * Physical shorthand properties that can be expanded into flow-relative longhands
+ *
+ * @see https://drafts.csswg.org/css-logical-1/#logical-shorthand-keyword
+ * @type {ReadonlySet<string>}
+ */
+export const physicalShorthandProperties = new Set([
+	'border-color',
+	'border-style',
+	'border-width',
+	'inset',
+	'margin',
+	'padding',
+	'scroll-margin',
+	'scroll-padding',
+]);
+
 /** @type {ReadonlyMap<string, string>} */
 export const physicalToFlowRelativeProperties = new Map([
 	// Margin properties

--- a/lib/rules/property-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/property-layout-mappings/__tests__/index.mjs
@@ -53,6 +53,30 @@ testRule({
 			code: 'a { will-change: auto; }',
 		},
 		{
+			code: 'a { margin: 1em; }',
+			description: 'single-value shorthand applies to every side',
+		},
+		{
+			code: 'a { inset: 0; }',
+			description: 'single-value shorthand applies to every side',
+		},
+		{
+			code: 'a { border-width: thin; }',
+			description: 'single-value shorthand applies to every side',
+		},
+		{
+			code: 'a { margin: var(--gap); }',
+			description: 'single var() value',
+		},
+		{
+			code: 'a { margin: logical 1em 2em; }',
+			description: 'the `logical` keyword is still in flux in the css-logical spec',
+		},
+		{
+			code: 'a { transition: margin 0s ease; }',
+			description: 'shorthand in transition-property means all margins',
+		},
+		{
 			code: '@page { margin-left: 0; }',
 		},
 		{
@@ -163,6 +187,42 @@ testRule({
 			endLine: 1,
 			endColumn: 31,
 		},
+		{
+			code: 'a { margin: 1em 2em; }',
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'physical shorthand without directionality config',
+		},
+		{
+			code: 'a { inset: 0 1em; }',
+			message: messages.rejected('physical', 'inset'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+			description: 'physical shorthand without directionality config',
+		},
+		{
+			code: 'a { border-width: thin thick; }',
+			message: messages.rejected('physical', 'border-width'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+			description: 'physical shorthand without directionality config',
+		},
+		{
+			code: 'a { margin: var(--gap) 1em; }',
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'var() can hold any number of values, so expanding is unsafe',
+		},
 	],
 });
 
@@ -185,6 +245,10 @@ testRule({
 		},
 		{
 			code: 'a { width: 0; }',
+		},
+		{
+			code: 'a { margin: 1em 2em; }',
+			description: 'physical shorthand',
 		},
 		{
 			code: 'a { transition-property: margin-left; }',
@@ -288,6 +352,10 @@ testRule({
 		},
 		{
 			code: 'a { transition: padding-left 0 ease; }',
+		},
+		{
+			code: 'a { margin: 1em 2em; }',
+			description: 'ignored physical shorthand',
 		},
 	],
 
@@ -1107,6 +1175,340 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 16,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['flow-relative'],
+	languageOptions: {
+		directionality: {
+			block: 'top-to-bottom',
+			inline: 'left-to-right',
+		},
+	},
+	fix: true,
+	computeEditInfo: true,
+
+	accept: [
+		{
+			code: 'a { margin: 1em; }',
+			description: 'single-value shorthand applies to every side',
+		},
+		{
+			code: 'a { inset: 0; }',
+			description: 'single-value shorthand applies to every side',
+		},
+		{
+			code: 'a { margin: var(--gap); }',
+			description: 'single var() value',
+		},
+		{
+			code: 'a { margin: logical 1em 2em; }',
+			description: 'the `logical` keyword is still in flux in the css-logical spec',
+		},
+		{
+			code: 'a { transition: margin 0s ease; }',
+			description: 'shorthand in transition-property means all margins',
+		},
+		{
+			code: 'a { margin: 1em 2em 3em 4em 5em; }',
+			description: 'invalid number of values is left to syntax-checking rules',
+		},
+		{
+			code: '@page { margin: 1em 2em; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { margin: 1em 2em; }',
+			fixed: 'a { margin-block: 1em; margin-inline: 2em; }',
+			fix: {
+				range: [19, 20],
+				text: '',
+			},
+			message: messages.expected('margin', 'margin-block, margin-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'two-value physical shorthand',
+		},
+		{
+			code: 'a { margin: 1em 2em 3em; }',
+			fixed: 'a { margin-block-start: 1em; margin-inline: 2em; margin-block-end: 3em; }',
+			fix: {
+				range: [23, 24],
+				text: '',
+			},
+			message: messages.expected('margin', 'margin-block-start, margin-inline, margin-block-end'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'three-value physical shorthand',
+		},
+		{
+			code: 'a { margin: 1em 2em 3em 4em; }',
+			fixed:
+				'a { margin-block-start: 1em; margin-inline-end: 2em; margin-block-end: 3em; margin-inline-start: 4em; }',
+			fix: {
+				range: [27, 28],
+				text: '',
+			},
+			message: messages.expected(
+				'margin',
+				'margin-block-start, margin-inline-end, margin-block-end, margin-inline-start',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'four-value physical shorthand',
+		},
+		{
+			code: 'a { margin: 1em 2em 3em 4em; transition: margin-left 0 ease; }',
+			fixed:
+				'a { margin-block-start: 1em; margin-inline-end: 2em; margin-block-end: 3em; margin-inline-start: 4em; transition: margin-inline-start 0 ease; }',
+			warnings: [
+				{
+					message: messages.expected(
+						'margin',
+						'margin-block-start, margin-inline-end, margin-block-end, margin-inline-start',
+					),
+					fix: {
+						range: [27, 28],
+						text: '',
+					},
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 11,
+				},
+				{
+					message: messages.expected('margin-left', 'margin-inline-start'),
+					fix: {
+						range: [48, 51],
+						text: 'inline-star',
+					},
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 53,
+				},
+			],
+			description: 'motivating example from the issue',
+		},
+		{
+			code: 'a { inset: 0 1em 2em 3em; }',
+			fixed:
+				'a { inset-block-start: 0; inset-inline-end: 1em; inset-block-end: 2em; inset-inline-start: 3em; }',
+			fix: {
+				range: [24, 25],
+				text: '',
+			},
+			message: messages.expected(
+				'inset',
+				'inset-block-start, inset-inline-end, inset-block-end, inset-inline-start',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+		},
+		{
+			code: 'a { border-width: thin thick; }',
+			fixed: 'a { border-block-width: thin; border-inline-width: thick; }',
+			fix: {
+				range: [28, 29],
+				text: '',
+			},
+			message: messages.expected('border-width', 'border-block-width, border-inline-width'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: 'a { border-style: solid dashed dotted double; }',
+			fixed:
+				'a { border-block-start-style: solid; border-inline-end-style: dashed; border-block-end-style: dotted; border-inline-start-style: double; }',
+			fix: {
+				range: [44, 45],
+				text: '',
+			},
+			message: messages.expected(
+				'border-style',
+				'border-block-start-style, border-inline-end-style, border-block-end-style, border-inline-start-style',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: 'a { border-color: red blue; }',
+			fixed: 'a { border-block-color: red; border-inline-color: blue; }',
+			fix: {
+				range: [26, 27],
+				text: '',
+			},
+			message: messages.expected('border-color', 'border-block-color, border-inline-color'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: 'a { scroll-margin: 1em 2em; }',
+			fixed: 'a { scroll-margin-block: 1em; scroll-margin-inline: 2em; }',
+			fix: {
+				range: [26, 27],
+				text: '',
+			},
+			message: messages.expected('scroll-margin', 'scroll-margin-block, scroll-margin-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 18,
+		},
+		{
+			code: 'a { scroll-padding: 1em 2em 3em; }',
+			fixed:
+				'a { scroll-padding-block-start: 1em; scroll-padding-inline: 2em; scroll-padding-block-end: 3em; }',
+			fix: {
+				range: [31, 32],
+				text: '',
+			},
+			message: messages.expected(
+				'scroll-padding',
+				'scroll-padding-block-start, scroll-padding-inline, scroll-padding-block-end',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 19,
+		},
+		{
+			code: 'a { padding: 0 1em; }',
+			fixed: 'a { padding-block: 0; padding-inline: 1em; }',
+			fix: {
+				range: [18, 19],
+				text: '',
+			},
+			message: messages.expected('padding', 'padding-block, padding-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 12,
+		},
+		{
+			code: 'a { margin: calc(1em + 2px) 2em !important; }',
+			fixed: 'a { margin-block: calc(1em + 2px) !important; margin-inline: 2em !important; }',
+			fix: {
+				range: [42, 43],
+				text: '',
+			},
+			message: messages.expected('margin', 'margin-block, margin-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'function values and !important are preserved',
+		},
+		{
+			code: 'a { margin: var(--gap) 1em; }',
+			unfixable: true,
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'var() can hold any number of values, so expanding is unsafe',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['flow-relative'],
+	languageOptions: {
+		directionality: {
+			block: 'top-to-bottom',
+			inline: 'right-to-left',
+		},
+	},
+	fix: true,
+	computeEditInfo: true,
+
+	reject: [
+		{
+			code: 'a { margin: 1em 2em 3em 4em; }',
+			fixed:
+				'a { margin-block-start: 1em; margin-inline-start: 2em; margin-block-end: 3em; margin-inline-end: 4em; }',
+			fix: {
+				range: [27, 28],
+				text: '',
+			},
+			message: messages.expected(
+				'margin',
+				'margin-block-start, margin-inline-start, margin-block-end, margin-inline-end',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'four-value physical shorthand with right-to-left inline direction',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['flow-relative'],
+	languageOptions: {
+		directionality: {
+			block: 'right-to-left',
+			inline: 'top-to-bottom',
+		},
+	},
+	fix: true,
+	computeEditInfo: true,
+
+	reject: [
+		{
+			code: 'a { margin: 1em 2em; }',
+			fixed: 'a { margin-inline: 1em; margin-block: 2em; }',
+			fix: {
+				range: [19, 20],
+				text: '',
+			},
+			message: messages.expected('margin', 'margin-inline, margin-block'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+			description: 'two-value physical shorthand with vertical inline direction',
+		},
+		{
+			code: 'a { inset: 0 1em 2em 3em; }',
+			fixed:
+				'a { inset-inline-start: 0; inset-block-start: 1em; inset-inline-end: 2em; inset-block-end: 3em; }',
+			fix: {
+				range: [24, 25],
+				text: '',
+			},
+			message: messages.expected(
+				'inset',
+				'inset-inline-start, inset-block-start, inset-inline-end, inset-block-end',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+			description: 'four-value physical shorthand with vertical inline direction',
 		},
 	],
 });

--- a/lib/rules/property-layout-mappings/index.mjs
+++ b/lib/rules/property-layout-mappings/index.mjs
@@ -2,6 +2,7 @@ import valueParser from 'postcss-value-parser';
 
 import {
 	flowRelativeProperties,
+	physicalShorthandProperties,
 	physicalToFlowRelativeProperties,
 } from '../../reference/properties.mjs';
 import { isAtRule, isValueWord } from '../../utils/typeGuards.mjs';
@@ -39,25 +40,37 @@ function isPageAtRule(node) {
 /** @import {Directionality} from 'stylelint' */
 
 /**
+ * Builds a physical side → logical position map based on the directionality config.
+ *
+ * @param {{ block: Directionality, inline: Directionality }} directionality
+ * @returns {Record<string, string>}
+ */
+function buildSideToLogical(directionality) {
+	const [blockStart, blockEnd] = directionFlowToSides(directionality.block);
+	const [inlineStart, inlineEnd] = directionFlowToSides(directionality.inline);
+
+	return {
+		[blockStart]: 'block-start',
+		[blockEnd]: 'block-end',
+		[inlineStart]: 'inline-start',
+		[inlineEnd]: 'inline-end',
+	};
+}
+
+/**
  * Builds a physical → flow-relative property map based on the directionality config.
  *
  * @param {{ block: Directionality, inline: Directionality }} directionality
  * @returns {Map<string, string>}
  */
 function buildDirectionalMap(directionality) {
-	const [blockStart, blockEnd] = directionFlowToSides(directionality.block);
-	const [inlineStart, inlineEnd] = directionFlowToSides(directionality.inline);
+	const [blockStart] = directionFlowToSides(directionality.block);
+	const [inlineStart] = directionFlowToSides(directionality.inline);
 
 	const inlineIsHorizontal =
 		directionality.inline === 'left-to-right' || directionality.inline === 'right-to-left';
 
-	/** @type {Record<string, string>} */
-	const sideToLogical = {
-		[blockStart]: 'block-start',
-		[blockEnd]: 'block-end',
-		[inlineStart]: 'inline-start',
-		[inlineEnd]: 'inline-end',
-	};
+	const sideToLogical = buildSideToLogical(directionality);
 
 	/** @type {Map<string, string>} */
 	const result = new Map();
@@ -150,6 +163,84 @@ function buildDirectionalMap(directionality) {
 	return result;
 }
 
+/**
+ * Returns the flow-relative property name for a physical box shorthand and logical position.
+ *
+ * @param {string} shorthand - e.g. 'margin', 'border-width'
+ * @param {string} axis - 'block' or 'inline'
+ * @param {string} [edge] - 'start' or 'end'; omitted for the two-edge shorthand
+ * @returns {string} - e.g. 'margin-block-start', 'border-inline-width'
+ */
+function flowRelativeBoxProperty(shorthand, axis, edge) {
+	// Border trait shorthands insert the logical position before the trait
+	if (shorthand.startsWith('border-')) {
+		const trait = shorthand.slice('border-'.length);
+
+		return edge ? `border-${axis}-${edge}-${trait}` : `border-${axis}-${trait}`;
+	}
+
+	return edge ? `${shorthand}-${axis}-${edge}` : `${shorthand}-${axis}`;
+}
+
+/**
+ * Expands a physical box shorthand into flow-relative declarations.
+ *
+ * @param {string} shorthand
+ * @param {string[]} values - 2–4 values in physical order (top, right, bottom, left)
+ * @param {Record<string, string>} sideToLogical - physical side → logical position
+ * @returns {Array<{ prop: string, value: string }>}
+ */
+function expandPhysicalShorthand(shorthand, values, sideToLogical) {
+	const sides = ['top', 'right', 'bottom', 'left'];
+	const [top = '', right = '', bottom = top, left = right] = values;
+
+	/** @type {Record<string, string>} */
+	const sideValues = { top, right, bottom, left };
+
+	/** @type {Record<string, string>} */
+	const valueAtLogicalPosition = {};
+
+	for (const side of sides) {
+		const logicalPosition = sideToLogical[side];
+
+		if (!logicalPosition) continue;
+
+		valueAtLogicalPosition[logicalPosition] = sideValues[side] ?? '';
+	}
+
+	// An axis collapses to its two-edge shorthand when both edges share a value
+	/** @type {Record<string, boolean>} */
+	const mergesAxis = {
+		block: valueAtLogicalPosition['block-start'] === valueAtLogicalPosition['block-end'],
+		inline: valueAtLogicalPosition['inline-start'] === valueAtLogicalPosition['inline-end'],
+	};
+
+	/** @type {Array<{ prop: string, value: string }>} */
+	const expansions = [];
+
+	const emittedAxes = new Set();
+
+	for (const side of sides) {
+		const logicalPosition = sideToLogical[side];
+
+		if (!logicalPosition) continue;
+
+		const [axis = '', edge] = logicalPosition.split('-');
+		const value = sideValues[side] ?? '';
+
+		if (mergesAxis[axis]) {
+			if (emittedAxes.has(axis)) continue;
+
+			emittedAxes.add(axis);
+			expansions.push({ prop: flowRelativeBoxProperty(shorthand, axis), value });
+		} else {
+			expansions.push({ prop: flowRelativeBoxProperty(shorthand, axis, edge), value });
+		}
+	}
+
+	return expansions;
+}
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -176,6 +267,7 @@ const rule = (primary, secondaryOptions) => {
 		const block = directionality?.block;
 		const inline = directionality?.inline;
 		const directionalMap = block && inline ? buildDirectionalMap({ block, inline }) : null;
+		const sideToLogical = block && inline ? buildSideToLogical({ block, inline }) : null;
 
 		/**
 		 * @param {string} type
@@ -193,6 +285,83 @@ const rule = (primary, secondaryOptions) => {
 				ruleName,
 				index,
 				endIndex,
+			});
+		}
+
+		/**
+		 * Checks a physical shorthand declaration that can be expanded into flow-relative longhands.
+		 *
+		 * @param {import('postcss').Declaration} decl
+		 */
+		function checkPhysicalShorthand(decl) {
+			const { prop } = decl;
+
+			if (findNodeUpToRoot(decl, isPageAtRule)) return;
+
+			const parsedValue = valueParser(getDeclarationValue(decl));
+
+			let containsVar = false;
+
+			parsedValue.walk((node) => {
+				if (node.type === 'function' && node.value.toLowerCase() === 'var') {
+					containsVar = true;
+				}
+			});
+
+			/** @type {import('postcss-value-parser').Node[]} */
+			const valueNodes = [];
+
+			for (const node of parsedValue.nodes) {
+				if (node.type === 'word' || node.type === 'function') valueNodes.push(node);
+			}
+
+			// A single value applies to every side and is already direction-agnostic
+			if (valueNodes.length < 2) return;
+
+			// Leave invalid declarations to syntax-checking rules
+			if (valueNodes.length > 4) return;
+
+			const [firstNode] = valueNodes;
+
+			// The `logical` keyword is still in flux in the css-logical spec
+			if (firstNode && firstNode.type === 'word' && firstNode.value.toLowerCase() === 'logical') {
+				return;
+			}
+
+			const index = 0;
+			const endIndex = index + prop.length;
+
+			// A `var()` can hold any number of values, so expanding is unsafe
+			if (containsVar || !directionalMap || !sideToLogical) {
+				complain('physical', prop, decl, index, endIndex);
+
+				return;
+			}
+
+			const expansions = expandPhysicalShorthand(
+				prop,
+				valueNodes.map((node) => valueParser.stringify(node)),
+				sideToLogical,
+			);
+
+			report({
+				message: messages.expected,
+				messageArgs: [prop, expansions.map(({ prop: expectedProp }) => expectedProp).join(', ')],
+				index,
+				endIndex,
+				node: decl,
+				result,
+				ruleName,
+				fix: {
+					apply: () => {
+						decl.replaceWith(
+							...expansions.map(({ prop: expandedProp, value }) =>
+								decl.clone({ prop: expandedProp, value }),
+							),
+						);
+					},
+					node: decl,
+				},
 			});
 		}
 
@@ -215,6 +384,12 @@ const rule = (primary, secondaryOptions) => {
 
 				complain('flow-relative', prop, decl, index, endIndex);
 			} else {
+				if (physicalShorthandProperties.has(prop)) {
+					checkPhysicalShorthand(decl);
+
+					return;
+				}
+
 				if (!physicalToFlowRelativeProperties.has(prop)) return;
 
 				if (findNodeUpToRoot(decl, isPageAtRule)) return;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #9420.

> Is there anything in the PR that needs further explanation?

In `flow-relative` mode the rule now reports 2–4 value physical shorthand declarations and autofixes them into flow-relative longhands, following the scope sketched in the issue: `inset`, `margin`, `padding`, `border-width`, `border-style`, `border-color`, `scroll-padding` and `scroll-margin`.

Expansion respects the configured `languageOptions.directionality`, including vertical writing modes; when both edges of an axis share a value, the two-edge shorthand is emitted instead (e.g. `margin: 1em 2em` → `margin-block: 1em; margin-inline: 2em`). Single-value shorthands apply symmetrically to every side, so they are still accepted.

Edge cases called out in the issue are handled as discussed: `transition: margin 0s ease` stays accepted (a shorthand in `transition-property` means all margins), values containing `var()` are still reported but never autofixed, and values starting with the `logical` keyword are left alone. `!important`, function values such as `calc()`, `ignoreProperties`, and the `@page` skip are preserved.
