### PR TITLE
Fix `property-layout-mappings` false negatives for physical shorthand properties

### DIFF
--- a/.changeset/quiet-boxes-shift.md
+++ b/.changeset/quiet-boxes-shift.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `property-layout-mappings` false negatives for physical shorthand properties

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -1117,6 +1117,23 @@ export const previouslyKnownPrefixedProperties = new Set([
 	'-webkit-wrap',
 ]);
 
+/**
+ * Physical box shorthands that expand into flow-relative longhands.
+ *
+ * @see https://drafts.csswg.org/css-logical-1/#logical-shorthand-keyword
+ * @type {ReadonlySet<string>}
+ */
+export const physicalShorthandProperties = new Set([
+	'border-color',
+	'border-style',
+	'border-width',
+	'inset',
+	'margin',
+	'padding',
+	'scroll-margin',
+	'scroll-padding',
+]);
+
 /** @type {ReadonlyMap<string, string>} */
 export const physicalToFlowRelativeProperties = new Map([
 	// Margin properties

--- a/lib/rules/property-layout-mappings/README.md
+++ b/lib/rules/property-layout-mappings/README.md
@@ -13,6 +13,8 @@ Physical layout properties like `margin-left` are tied to the physical dimension
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix problems reported by this rule when both the primary option is `"flow-relative"` and the [`languageOptions.directionality`](../../../docs/user-guide/configure.md#directionality) configuration property is configured.
 
+This rule also flags 2–4 value physical box shorthands (`margin`, `padding`, `inset`, `border-width`, `border-style`, `border-color`, `scroll-margin`, and `scroll-padding`) and expands them into flow-relative longhands when `languageOptions.directionality` is configured. Single-value shorthands apply to every side, so they are accepted. A shorthand name in `transition` or `will-change` is also accepted because it refers to all sides.
+
 This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the disallowed mapping and the property, or the physical property and its flow-relative equivalent.
 
 Prior art:
@@ -68,6 +70,11 @@ a { width: 0; }
 a { transition: margin-left 0 ease; }
 ```
 
+<!-- prettier-ignore -->
+```css
+a { margin: 1em 2em; }
+```
+
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
@@ -83,6 +90,16 @@ a { inline-size: 0; }
 <!-- prettier-ignore -->
 ```css
 a { transition: margin-inline-start 0 ease; }
+```
+
+<!-- prettier-ignore -->
+```css
+a { margin: 1em; }
+```
+
+<!-- prettier-ignore -->
+```css
+a { transition: margin 0s ease; }
 ```
 
 ### `"physical"`

--- a/lib/rules/property-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/property-layout-mappings/__tests__/index.mjs
@@ -53,6 +53,18 @@ testRule({
 			code: 'a { will-change: auto; }',
 		},
 		{
+			code: 'a { margin: 1em; }',
+		},
+		{
+			code: 'a { margin: var(--foo); }',
+		},
+		{
+			code: 'a { margin: logical 1em 2em; }',
+		},
+		{
+			code: 'a { transition: margin 0s ease; }',
+		},
+		{
 			code: '@page { margin-left: 0; }',
 		},
 		{
@@ -163,6 +175,30 @@ testRule({
 			endLine: 1,
 			endColumn: 31,
 		},
+		{
+			code: 'a { margin: 1em 2em; }',
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: 'a { inset: 0 1em; }',
+			message: messages.rejected('physical', 'inset'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+		},
+		{
+			code: 'a { margin: var(--foo) 1em; }',
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
 	],
 });
 
@@ -185,6 +221,9 @@ testRule({
 		},
 		{
 			code: 'a { width: 0; }',
+		},
+		{
+			code: 'a { margin: 1em 2em; }',
 		},
 		{
 			code: 'a { transition-property: margin-left; }',
@@ -288,6 +327,9 @@ testRule({
 		},
 		{
 			code: 'a { transition: padding-left 0 ease; }',
+		},
+		{
+			code: 'a { margin: 1em 2em; }',
 		},
 	],
 
@@ -1107,6 +1149,269 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 16,
+		},
+		{
+			code: 'a { margin: 1em 2em; }',
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['flow-relative'],
+	languageOptions: {
+		directionality: {
+			block: 'top-to-bottom',
+			inline: 'left-to-right',
+		},
+	},
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { margin: 1em; }',
+		},
+		{
+			code: 'a { inset: 0; }',
+		},
+		{
+			code: 'a { margin: var(--foo); }',
+		},
+		{
+			code: 'a { margin: logical 1em 2em; }',
+		},
+		{
+			code: 'a { margin: LOGICAL 1em 2em; }',
+		},
+		{
+			code: 'a { transition: margin 0s ease; }',
+		},
+		{
+			code: 'a { margin: 1em 2em 3em 4em 5em; }',
+		},
+		{
+			code: '@page { margin: 1em 2em; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { margin: 1em 2em; }',
+			fixed: 'a { margin-block: 1em; margin-inline: 2em; }',
+			message: messages.expected('margin', 'margin-block, margin-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: 'a { margin: 1em 2em 3em; }',
+			fixed: 'a { margin-block-start: 1em; margin-inline: 2em; margin-block-end: 3em; }',
+			message: messages.expected('margin', 'margin-block-start, margin-inline, margin-block-end'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: 'a { margin: 1em 2em 3em 4em; }',
+			fixed:
+				'a { margin-block-start: 1em; margin-inline-end: 2em; margin-block-end: 3em; margin-inline-start: 4em; }',
+			message: messages.expected(
+				'margin',
+				'margin-block-start, margin-inline-end, margin-block-end, margin-inline-start',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: 'a { margin: 1em 2em 3em 4em; transition: margin-left 0 ease; }',
+			fixed:
+				'a { margin-block-start: 1em; margin-inline-end: 2em; margin-block-end: 3em; margin-inline-start: 4em; transition: margin-inline-start 0 ease; }',
+			warnings: [
+				{
+					message: messages.expected(
+						'margin',
+						'margin-block-start, margin-inline-end, margin-block-end, margin-inline-start',
+					),
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 11,
+				},
+				{
+					message: messages.expected('margin-left', 'margin-inline-start'),
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 53,
+				},
+			],
+		},
+		{
+			code: 'a { inset: 0 1em 2em 3em; }',
+			fixed:
+				'a { inset-block-start: 0; inset-inline-end: 1em; inset-block-end: 2em; inset-inline-start: 3em; }',
+			message: messages.expected(
+				'inset',
+				'inset-block-start, inset-inline-end, inset-block-end, inset-inline-start',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+		},
+		{
+			code: 'a { padding: 0 1em; }',
+			fixed: 'a { padding-block: 0; padding-inline: 1em; }',
+			message: messages.expected('padding', 'padding-block, padding-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 12,
+		},
+		{
+			code: 'a { border-width: thin thick; }',
+			fixed: 'a { border-block-width: thin; border-inline-width: thick; }',
+			message: messages.expected('border-width', 'border-block-width, border-inline-width'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: 'a { border-style: solid dashed dotted double; }',
+			fixed:
+				'a { border-block-start-style: solid; border-inline-end-style: dashed; border-block-end-style: dotted; border-inline-start-style: double; }',
+			message: messages.expected(
+				'border-style',
+				'border-block-start-style, border-inline-end-style, border-block-end-style, border-inline-start-style',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: 'a { border-color: red blue; }',
+			fixed: 'a { border-block-color: red; border-inline-color: blue; }',
+			message: messages.expected('border-color', 'border-block-color, border-inline-color'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: 'a { scroll-margin: 1em 2em; }',
+			fixed: 'a { scroll-margin-block: 1em; scroll-margin-inline: 2em; }',
+			message: messages.expected('scroll-margin', 'scroll-margin-block, scroll-margin-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 18,
+		},
+		{
+			code: 'a { scroll-padding: 1em 2em 3em; }',
+			fixed:
+				'a { scroll-padding-block-start: 1em; scroll-padding-inline: 2em; scroll-padding-block-end: 3em; }',
+			message: messages.expected(
+				'scroll-padding',
+				'scroll-padding-block-start, scroll-padding-inline, scroll-padding-block-end',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 19,
+		},
+		{
+			code: 'a { margin: calc(1em + 2px) 2em !important; }',
+			fixed: 'a { margin-block: calc(1em + 2px) !important; margin-inline: 2em !important; }',
+			message: messages.expected('margin', 'margin-block, margin-inline'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: 'a { margin: var(--foo) 1em; }',
+			unfixable: true,
+			message: messages.rejected('physical', 'margin'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['flow-relative'],
+	languageOptions: {
+		directionality: {
+			block: 'top-to-bottom',
+			inline: 'right-to-left',
+		},
+	},
+	fix: true,
+
+	reject: [
+		{
+			code: 'a { margin: 1em 2em 3em 4em; }',
+			fixed:
+				'a { margin-block-start: 1em; margin-inline-start: 2em; margin-block-end: 3em; margin-inline-end: 4em; }',
+			message: messages.expected(
+				'margin',
+				'margin-block-start, margin-inline-start, margin-block-end, margin-inline-end',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['flow-relative'],
+	languageOptions: {
+		directionality: {
+			block: 'right-to-left',
+			inline: 'top-to-bottom',
+		},
+	},
+	fix: true,
+
+	reject: [
+		{
+			code: 'a { margin: 1em 2em; }',
+			fixed: 'a { margin-inline: 1em; margin-block: 2em; }',
+			message: messages.expected('margin', 'margin-inline, margin-block'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: 'a { inset: 0 1em 2em 3em; }',
+			fixed:
+				'a { inset-inline-start: 0; inset-block-start: 1em; inset-inline-end: 2em; inset-block-end: 3em; }',
+			message: messages.expected(
+				'inset',
+				'inset-inline-start, inset-block-start, inset-inline-end, inset-block-end',
+			),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
 		},
 	],
 });

--- a/lib/rules/property-layout-mappings/index.mjs
+++ b/lib/rules/property-layout-mappings/index.mjs
@@ -2,9 +2,10 @@ import valueParser from 'postcss-value-parser';
 
 import {
 	flowRelativeProperties,
+	physicalShorthandProperties,
 	physicalToFlowRelativeProperties,
 } from '../../reference/properties.mjs';
-import { isAtRule, isValueWord } from '../../utils/typeGuards.mjs';
+import { isAtRule, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import directionFlowToSides from '../../utils/directionFlowToSides.mjs';
@@ -12,6 +13,7 @@ import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
 import isStandardSyntaxProperty from '../../utils/isStandardSyntaxProperty.mjs';
+import isVarFunction from '../../utils/isVarFunction.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import { propertyRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
@@ -39,25 +41,37 @@ function isPageAtRule(node) {
 /** @import {Directionality} from 'stylelint' */
 
 /**
+ * Builds a physical side → logical position map based on the directionality config.
+ *
+ * @param {{ block: Directionality, inline: Directionality }} directionality
+ * @returns {Record<string, string>}
+ */
+function buildSideToLogical(directionality) {
+	const [blockStart, blockEnd] = directionFlowToSides(directionality.block);
+	const [inlineStart, inlineEnd] = directionFlowToSides(directionality.inline);
+
+	return {
+		[blockStart]: 'block-start',
+		[blockEnd]: 'block-end',
+		[inlineStart]: 'inline-start',
+		[inlineEnd]: 'inline-end',
+	};
+}
+
+/**
  * Builds a physical → flow-relative property map based on the directionality config.
  *
  * @param {{ block: Directionality, inline: Directionality }} directionality
  * @returns {Map<string, string>}
  */
 function buildDirectionalMap(directionality) {
-	const [blockStart, blockEnd] = directionFlowToSides(directionality.block);
-	const [inlineStart, inlineEnd] = directionFlowToSides(directionality.inline);
+	const [blockStart] = directionFlowToSides(directionality.block);
+	const [inlineStart] = directionFlowToSides(directionality.inline);
 
 	const inlineIsHorizontal =
 		directionality.inline === 'left-to-right' || directionality.inline === 'right-to-left';
 
-	/** @type {Record<string, string>} */
-	const sideToLogical = {
-		[blockStart]: 'block-start',
-		[blockEnd]: 'block-end',
-		[inlineStart]: 'inline-start',
-		[inlineEnd]: 'inline-end',
-	};
+	const sideToLogical = buildSideToLogical(directionality);
 
 	/** @type {Map<string, string>} */
 	const result = new Map();
@@ -150,6 +164,78 @@ function buildDirectionalMap(directionality) {
 	return result;
 }
 
+/**
+ * Returns the flow-relative property name for a physical box shorthand and logical position.
+ *
+ * @param {string} shorthand
+ * @param {string} axis
+ * @param {string} [edge]
+ * @returns {string}
+ */
+function flowRelativeBoxProperty(shorthand, axis, edge) {
+	if (shorthand.startsWith('border-')) {
+		const trait = shorthand.slice('border-'.length);
+
+		return edge ? `border-${axis}-${edge}-${trait}` : `border-${axis}-${trait}`;
+	}
+
+	return edge ? `${shorthand}-${axis}-${edge}` : `${shorthand}-${axis}`;
+}
+
+/**
+ * Expands a physical box shorthand into flow-relative declarations.
+ *
+ * @param {string} shorthand
+ * @param {string[]} values
+ * @param {Record<string, string>} sideToLogical
+ * @returns {Array<{ prop: string, value: string }>}
+ */
+function expandPhysicalShorthand(shorthand, values, sideToLogical) {
+	const [top = '', right = '', bottom = top, left = right] = values;
+	/** @type {Record<string, string>} */
+	const sideValues = { top, right, bottom, left };
+	/** @type {Record<string, string>} */
+	const logicalValues = {};
+
+	for (const side of ['top', 'right', 'bottom', 'left']) {
+		const logicalPosition = sideToLogical[side];
+
+		if (!logicalPosition) continue;
+
+		logicalValues[logicalPosition] = sideValues[side] ?? '';
+	}
+
+	/** @type {Record<string, boolean>} */
+	const mergesAxis = {
+		block: logicalValues['block-start'] === logicalValues['block-end'],
+		inline: logicalValues['inline-start'] === logicalValues['inline-end'],
+	};
+
+	/** @type {Array<{ prop: string, value: string }>} */
+	const expansions = [];
+	const emittedAxes = new Set();
+
+	for (const side of ['top', 'right', 'bottom', 'left']) {
+		const logicalPosition = sideToLogical[side];
+
+		if (!logicalPosition) continue;
+
+		const [axis = '', edge] = logicalPosition.split('-');
+		const value = sideValues[side] ?? '';
+
+		if (mergesAxis[axis]) {
+			if (emittedAxes.has(axis)) continue;
+
+			emittedAxes.add(axis);
+			expansions.push({ prop: flowRelativeBoxProperty(shorthand, axis), value });
+		} else {
+			expansions.push({ prop: flowRelativeBoxProperty(shorthand, axis, edge), value });
+		}
+	}
+
+	return expansions;
+}
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -176,6 +262,7 @@ const rule = (primary, secondaryOptions) => {
 		const block = directionality?.block;
 		const inline = directionality?.inline;
 		const directionalMap = block && inline ? buildDirectionalMap({ block, inline }) : null;
+		const sideToLogical = block && inline ? buildSideToLogical({ block, inline }) : null;
 
 		/**
 		 * @param {string} type
@@ -193,6 +280,75 @@ const rule = (primary, secondaryOptions) => {
 				ruleName,
 				index,
 				endIndex,
+			});
+		}
+
+		/**
+		 * @param {import('postcss').Declaration} decl
+		 */
+		function checkPhysicalShorthand(decl) {
+			const { prop, parent } = decl;
+
+			if (findNodeUpToRoot(decl, isPageAtRule)) return;
+
+			const parsedValue = valueParser(getDeclarationValue(decl));
+			/** @type {import('postcss-value-parser').Node[]} */
+			const valueNodes = [];
+
+			for (const node of parsedValue.nodes) {
+				if (isValueWord(node) || isValueFunction(node)) {
+					valueNodes.push(node);
+				}
+			}
+
+			// A single value applies to every side
+			if (valueNodes.length < 2) return;
+
+			// Leave invalid declarations to syntax-checking rules
+			if (valueNodes.length > 4) return;
+
+			const [firstNode] = valueNodes;
+
+			// The `logical` keyword is still in flux in the css-logical spec
+			if (firstNode && isValueWord(firstNode) && firstNode.value.toLowerCase() === 'logical') {
+				return;
+			}
+
+			const index = 0;
+			const endIndex = index + prop.length;
+			const containsVar = valueNodes.some((node) => isVarFunction(node));
+
+			// A top-level `var()` can substitute any number of values
+			if (containsVar || !sideToLogical || !parent) {
+				complain('physical', prop, decl, index, endIndex);
+
+				return;
+			}
+
+			const expansions = expandPhysicalShorthand(
+				prop,
+				valueNodes.map((node) => valueParser.stringify(node)),
+				sideToLogical,
+			);
+
+			report({
+				message: messages.expected,
+				messageArgs: [prop, expansions.map(({ prop: expectedProp }) => expectedProp).join(', ')],
+				index,
+				endIndex,
+				node: decl,
+				result,
+				ruleName,
+				fix: {
+					apply: () => {
+						decl.replaceWith(
+							...expansions.map(({ prop: expandedProp, value }) =>
+								decl.clone({ prop: expandedProp, value }),
+							),
+						);
+					},
+					node: parent,
+				},
 			});
 		}
 
@@ -215,6 +371,12 @@ const rule = (primary, secondaryOptions) => {
 
 				complain('flow-relative', prop, decl, index, endIndex);
 			} else {
+				if (physicalShorthandProperties.has(prop)) {
+					checkPhysicalShorthand(decl);
+
+					return;
+				}
+
 				if (!physicalToFlowRelativeProperties.has(prop)) return;
 
 				if (findNodeUpToRoot(decl, isPageAtRule)) return;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #9420.

> Is there anything in the PR that needs further explanation?

The rule now expands 2–4 value physical box shorthands (`margin`, `padding`, `inset`, etc.) into flow-relative longhands. Single-value shorthands, `transition: margin`, and the `logical` keyword are left alone. Values with `var()` are reported but not autofixed.

Fixes #9420