### PR TITLE
Fix `declaration-property-max-values` false positives for interpolated inline expressions

### DIFF
--- a/.changeset/bright-moles-cheer.md
+++ b/.changeset/bright-moles-cheer.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-max-values` false positives for interpolated inline expressions

--- a/lib/rules/declaration-property-max-values/__tests__/index.mjs
+++ b/lib/rules/declaration-property-max-values/__tests__/index.mjs
@@ -46,6 +46,9 @@ testRule({
 			code: 'a { transition: margin-right 2s ease-in-out; }',
 			description: 'irrelevant shorthand',
 		},
+		{
+			code: 'a { margin: $variable 1em; }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/declaration-property-max-values/index.mjs
+++ b/lib/rules/declaration-property-max-values/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { isValueFunction, isValueString, isValueWord } from '../../utils/typeGuards.mjs';
 import { assertNumber } from '../../utils/validateTypes.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
+import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
@@ -43,6 +44,8 @@ const rule = (primary) => {
 			const { prop, value } = decl;
 
 			if (!mayIncludeRegexes.multipleValues.test(value)) return;
+
+			if (!isStandardSyntaxValue(value)) return;
 
 			const propLength = valueParser(value).nodes.filter(isValueNode).length;
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #9422.

> Is there anything in the PR that needs further explanation?

The rule now skips declaration values that aren't standard CSS via `isStandardSyntaxValue`, as suggested in the issue. This covers SCSS variables, `#{...}` interpolations and css-in-js `${...}` expressions, so they are no longer counted as values and the rule reports fewer false positives.

The new tests use postcss-scss syntax; the css-in-js case is handled by the same check.
