### PR TITLE
Add `--source` and `--config` options to rule benchmark script

### DIFF
--- a/docs/contributor-guide/benchmarks.md
+++ b/docs/contributor-guide/benchmarks.md
@@ -18,7 +18,7 @@ Improving the performance of a rule is a great way to contribute if you want a q
 You can run a benchmark on any given rule with any valid config using:
 
 ```shell
-npm run benchmark-rule -- ruleName ruleOptions [config]
+npm run benchmark-rule -- ruleName ruleOptions [options]
 ```
 
 For example:
@@ -27,11 +27,27 @@ For example:
 npm run benchmark-rule -- value-keyword-case lower
 ```
 
-If the `ruleOptions` or `config` arguments are anything other than a string or a boolean, they must be valid JSON wrapped in quotation marks. For example:
+If the `ruleOptions` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks. For example:
 
 ```shell
-npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'
+npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
 ```
+
+Use `--config` to pass extra lint options as JSON:
+
+```shell
+npm run benchmark-rule -- value-keyword-case lower --config='{"fix": true}'
+```
+
+### Custom sources
+
+By default the script benchmarks against a fixed set of real-world stylesheets. Use the repeatable `--source` option to benchmark against your own CSS instead — either local files or URLs:
+
+```shell
+npm run benchmark-rule -- value-keyword-case lower --source=a.css
+```
+
+This is useful for abnormal CSS, such as a selector with too many combinators, which real-world stylesheets rarely contain.
 
 ### Interpreting results
 
@@ -50,7 +66,7 @@ Compare the results with those of:
 
 ### Implementation details
 
-The script loads Bootstrap's CSS (from its CDN) and runs it through the configured rule.
+The script loads the source stylesheets (fetching any URLs), concatenates them, repeats the result a fixed number of times to get a stable mean, and runs it through the configured rule.
 
 ## System benchmarking
 

--- a/scripts/benchmarking/run-rule.mjs
+++ b/scripts/benchmarking/run-rule.mjs
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 import { argv, exit } from 'node:process';
+import { parseArgs } from 'node:util';
+import { readFile } from 'node:fs/promises';
 
 import { Bench } from 'tinybench';
 import picocolors from 'picocolors';
@@ -8,28 +10,82 @@ import stylelint from '../../lib/index.mjs';
 
 const { bold, red, yellow } = picocolors;
 
-const [, , ruleName, ruleOptions, config] = argv;
+const DEFAULT_SOURCES = [
+	'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.css',
+	'https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.2.1/dist-cdn/styles/native.css',
+	'https://cdn.jsdelivr.net/npm/kelpui@1.17.2/css/kelp.css',
+];
 
 function printHelp() {
 	const script = 'node benchmark-rule.mjs';
 
-	console.log(`Usage: ${script} <ruleName> <ruleOptions> [config]`);
-	console.log('');
-	console.log('Examples:');
-	console.log('  # With a primary option');
-	console.log(`  ${script} value-keyword-case lower`);
-	console.log('');
-	console.log('  # With secondary options (JSON format)');
-	console.log(`  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'`);
-	console.log('');
-	console.log('  # With a config');
-	console.log(
-		`  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'`,
-	);
+	console.log(`Usage: ${script} <ruleName> <ruleOptions> [options]
+
+Arguments:
+  <ruleName>           Rule name.
+  <ruleOptions>        Rule options (JSON format, or a bare string).
+
+Options:
+  --source=<file|url>  Source CSS, replacing the defaults. Repeatable.
+  --config=<json>      Extra lint options (JSON format), e.g. '{"fix": true}'.
+  --help, -h           Show the help message.
+
+Examples:
+  # With a primary option
+  ${script} value-keyword-case lower
+
+  # With secondary options (JSON format)
+  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
+
+  # With a config
+  ${script} value-keyword-case lower --config='{"fix": true}'
+
+  # Against local files instead of the default sources
+  ${script} value-keyword-case lower --source=a.css --source=b.css`);
+}
+
+let parsedArgs;
+
+try {
+	parsedArgs = parseArgs({
+		args: argv.slice(2),
+		options: {
+			source: { type: 'string', multiple: true, default: DEFAULT_SOURCES },
+			config: { type: 'string' },
+			help: { type: 'boolean', short: 'h', default: false },
+		},
+		allowPositionals: true,
+	});
+} catch (error) {
+	console.error(error.message);
+	printHelp();
+	exit(1);
+}
+
+const {
+	values: { source: sources, config, help },
+	positionals: [ruleName, ruleOptions, ...unexpectedPositionals],
+} = parsedArgs;
+
+if (help) {
+	printHelp();
+	exit(0);
 }
 
 if (!ruleName || !ruleOptions) {
 	printHelp();
+	exit(1);
+}
+
+if (unexpectedPositionals.length > 0) {
+	console.error(`Unexpected argument: ${unexpectedPositionals[0]}`);
+	exit(1);
+}
+
+const duplicateSource = sources.find((source, index) => sources.indexOf(source) !== index);
+
+if (duplicateSource) {
+	console.error(`Duplicate source: ${duplicateSource}`);
 	exit(1);
 }
 
@@ -38,17 +94,30 @@ if (!stylelint.rules[ruleName]) {
 	exit(1);
 }
 
-const CSS_URLs = [
-	'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.css',
-	'https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.2.1/dist-cdn/styles/native.css',
-	'https://cdn.jsdelivr.net/npm/kelpui@1.17.2/css/kelp.css',
-];
+/**
+ * @param {string} source A file path or an HTTP(S) URL.
+ * @returns {Promise<string>}
+ */
+async function readSource(source) {
+	if (!/^https?:\/\//i.test(source)) {
+		return readFile(source, 'utf8');
+	}
+
+	// eslint-disable-next-line n/no-unsupported-features/node-builtins -- This script is only for development. We can tolerate it.
+	const response = await fetch(source);
+
+	if (!response.ok) {
+		throw new Error(`Failed to fetch ${source}: ${response.status} ${response.statusText}`);
+	}
+
+	return response.text();
+}
 
 // PostCSS and modern hardware is too fast to benchmark with a small source.
 // Duplicating the source CSS N times gives a larger mean while reducing the deviation.
 //
 // 5 was chosen because it gives a mean in the 50-200ms range
-// with a deviation that is ±10% of the mean.
+// with a deviation that is ±10% of the mean for the default sources.
 const DUPLICATE_SOURCE_N_TIMES = 5;
 
 let parsedOptions = ruleOptions;
@@ -74,10 +143,20 @@ const lintConfig = {
 };
 const lint = (code) => stylelint.lint({ code, config: lintConfig });
 
-// eslint-disable-next-line n/no-unsupported-features/node-builtins -- This script is only for development. We can tolerate it.
-const responses = await Promise.all(CSS_URLs.map((url) => fetch(url).then((res) => res.text())));
-const source = responses.join('\n\n');
+/** @type {Array<string>} */
+let contents;
+
+try {
+	contents = await Promise.all(sources.map(readSource));
+} catch (error) {
+	console.error(bold(red(`Failed to read source: ${error.message}`)));
+	exit(1);
+}
+
+const source = contents.join('\n\n');
 const css = `${source}\n\n`.repeat(DUPLICATE_SOURCE_N_TIMES);
+
+console.log(`${bold('Sources')}: ${sources.join(', ')} (×${DUPLICATE_SOURCE_N_TIMES})`);
 
 const TASK_NAME = 'rule test';
 const bench = new Bench({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I'd like to be able to run the benchmark against any CSS code ad hoc. The default CDN stylesheets are ordinary real-world CSS and rarely contain abnormal CSS, such as too many selectors.

Also, this replaces the positional `config` argument with `--config` for usability.

Examples:

```shell
npm run benchmark-rule -- value-keyword-case lower --source=a.css
```

```shell
npm run benchmark-rule -- value-keyword-case lower --config='{"fix": true}'
```
