### PR TITLE
Add `ignoreFunctions: []` to `color-named` and `color-no-hex`

### DIFF
--- a/.changeset/color-rules-ignore-functions.md
+++ b/.changeset/color-rules-ignore-functions.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `ignoreFunctions` secondary option to `color-named` and `color-no-hex` rules

--- a/.changeset/color-rules-ignore-functions.md
+++ b/.changeset/color-rules-ignore-functions.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `ignoreFunctions` secondary option to `color-named` and `color-no-hex` rules
+Added: `ignoreFunctions: []` to `color-named` and `color-no-hex`

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -166,6 +166,34 @@ a {
 }
 ```
 
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
+
+Ignore named colors within the specified functions. This is a more targeted alternative to the `ignore: ["inside-function"]` option, which ignores colors inside all functions.
+
+Given:
+
+```json
+{
+  "color-named": ["never", { "ignoreFunctions": ["var", "/^--/"] }]
+}
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a { color: var(--foo, red); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: --bar(red); }
+```
+
 ### `ignoreProperties`
 
 ```json

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -172,7 +172,7 @@ a {
 { "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
 ```
 
-Ignore named colors within the specified functions. This is a more targeted alternative to the `ignore: ["inside-function"]` option, which ignores colors inside all functions.
+Ignore named colors within the specified functions.
 
 Given:
 
@@ -191,7 +191,7 @@ a { color: var(--foo, red); }
 
 <!-- prettier-ignore -->
 ```css
-a { color: --bar(red); }
+a { color: --foo(red); }
 ```
 
 ### `ignoreProperties`

--- a/lib/rules/color-named/__tests__/index.mjs
+++ b/lib/rules/color-named/__tests__/index.mjs
@@ -578,7 +578,7 @@ testRule({
 		},
 		{
 			code: 'a { color: --foo(#000); }',
-		},	
+		},
 	],
 
 	reject: [

--- a/lib/rules/color-named/__tests__/index.mjs
+++ b/lib/rules/color-named/__tests__/index.mjs
@@ -535,43 +535,19 @@ testRule({
 
 	accept: [
 		{
-			code: 'a { color: var(--foo, red); }',
-			description: 'named color as var() fallback',
-		},
-		{
-			code: 'a { color: var(--foo, RED); }',
-			description: 'named color (uppercase) as var() fallback',
-		},
-		{
-			code: 'a { color: var(--foo, var(--bar, red)); }',
-			description: 'named color as nested var() fallback',
-		},
-		{
-			code: 'a { color: var(--foo, rebeccapurple); }',
-			description: 'named color as var() fallback',
-		},
-		{
-			code: 'a { border: var(--border, 1px solid red); }',
-			description: 'named color within var() fallback mixed with other values',
-		},
-		{
-			code: 'a { color: --bar(red); }',
-			description: 'named color inside function matching /^--/',
-		},
-		{
 			code: 'a { color: #000; }',
-			description: 'hex colors are not affected by this rule',
 		},
 		{
-			code: 'a { color: var(--some-color-blue); }',
-			description: 'css variable named with a color word is not flagged',
+			code: 'a { color: var(--foo, red); }',
+		},
+		{
+			code: 'a { color: --foo(red); }',
 		},
 	],
 
 	reject: [
 		{
 			code: 'a { color: red; }',
-			description: 'named color outside any function is still flagged',
 			message: messages.rejected('red'),
 			line: 1,
 			column: 12,
@@ -580,21 +556,11 @@ testRule({
 		},
 		{
 			code: 'a { color: red var(--foo, blue); }',
-			description: 'named color outside var() is still flagged even when var() fallback is present',
 			message: messages.rejected('red'),
 			line: 1,
 			column: 12,
 			endLine: 1,
 			endColumn: 15,
-		},
-		{
-			code: 'a { color: map-get($color, blue); }',
-			description: 'named color inside a non-ignored function is still flagged',
-			message: messages.rejected('blue'),
-			line: 1,
-			column: 28,
-			endLine: 1,
-			endColumn: 32,
 		},
 	],
 });
@@ -605,54 +571,24 @@ testRule({
 
 	accept: [
 		{
+			code: 'a { color: black; }',
+		},
+		{
 			code: 'a { color: var(--foo, #000); }',
-			description: 'hex color as var() fallback is ignored',
-		},
-		{
-			code: 'a { color: var(--foo, rgb(0, 0, 0)); }',
-			description: 'color function as var() fallback is ignored',
-		},
-		{
-			code: 'a { color: var(--foo, var(--bar, #000)); }',
-			description: 'hex color as nested var() fallback is ignored',
 		},
 		{
 			code: 'a { color: --bar(#000); }',
-			description: 'hex color inside function matching /^--/ is ignored',
-		},
-		{
-			code: 'a { color: black; }',
-			description: 'named colors remain valid',
-		},
+		},	
 	],
 
 	reject: [
 		{
 			code: 'a { color: #000; }',
-			description: 'hex color outside any function is still flagged',
 			message: messages.expected('#000', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
 			endColumn: 16,
-		},
-		{
-			code: 'a { color: #000 var(--foo, #fff); }',
-			description: 'hex color outside var() is still flagged even when var() fallback is present',
-			message: messages.expected('#000', 'black'),
-			line: 1,
-			column: 12,
-			endLine: 1,
-			endColumn: 16,
-		},
-		{
-			code: 'a { color: rgb(0, 0, 0); }',
-			description: 'color function outside an ignored function is still flagged',
-			message: messages.expected('rgb(0,0,0)', 'black'),
-			line: 1,
-			column: 12,
-			endLine: 1,
-			endColumn: 24,
 		},
 	],
 });

--- a/lib/rules/color-named/__tests__/index.mjs
+++ b/lib/rules/color-named/__tests__/index.mjs
@@ -528,3 +528,131 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: ['never', { ignoreFunctions: ['var', /^--/] }],
+
+	accept: [
+		{
+			code: 'a { color: var(--foo, red); }',
+			description: 'named color as var() fallback',
+		},
+		{
+			code: 'a { color: var(--foo, RED); }',
+			description: 'named color (uppercase) as var() fallback',
+		},
+		{
+			code: 'a { color: var(--foo, var(--bar, red)); }',
+			description: 'named color as nested var() fallback',
+		},
+		{
+			code: 'a { color: var(--foo, rebeccapurple); }',
+			description: 'named color as var() fallback',
+		},
+		{
+			code: 'a { border: var(--border, 1px solid red); }',
+			description: 'named color within var() fallback mixed with other values',
+		},
+		{
+			code: 'a { color: --bar(red); }',
+			description: 'named color inside function matching /^--/',
+		},
+		{
+			code: 'a { color: #000; }',
+			description: 'hex colors are not affected by this rule',
+		},
+		{
+			code: 'a { color: var(--some-color-blue); }',
+			description: 'css variable named with a color word is not flagged',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: red; }',
+			description: 'named color outside any function is still flagged',
+			message: messages.rejected('red'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 15,
+		},
+		{
+			code: 'a { color: red var(--foo, blue); }',
+			description: 'named color outside var() is still flagged even when var() fallback is present',
+			message: messages.rejected('red'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 15,
+		},
+		{
+			code: 'a { color: map-get($color, blue); }',
+			description: 'named color inside a non-ignored function is still flagged',
+			message: messages.rejected('blue'),
+			line: 1,
+			column: 28,
+			endLine: 1,
+			endColumn: 32,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['always-where-possible', { ignoreFunctions: ['var', /^--/] }],
+
+	accept: [
+		{
+			code: 'a { color: var(--foo, #000); }',
+			description: 'hex color as var() fallback is ignored',
+		},
+		{
+			code: 'a { color: var(--foo, rgb(0, 0, 0)); }',
+			description: 'color function as var() fallback is ignored',
+		},
+		{
+			code: 'a { color: var(--foo, var(--bar, #000)); }',
+			description: 'hex color as nested var() fallback is ignored',
+		},
+		{
+			code: 'a { color: --bar(#000); }',
+			description: 'hex color inside function matching /^--/ is ignored',
+		},
+		{
+			code: 'a { color: black; }',
+			description: 'named colors remain valid',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: #000; }',
+			description: 'hex color outside any function is still flagged',
+			message: messages.expected('#000', 'black'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 16,
+		},
+		{
+			code: 'a { color: #000 var(--foo, #fff); }',
+			description: 'hex color outside var() is still flagged even when var() fallback is present',
+			message: messages.expected('#000', 'black'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 16,
+		},
+		{
+			code: 'a { color: rgb(0, 0, 0); }',
+			description: 'color function outside an ignored function is still flagged',
+			message: messages.expected('rgb(0,0,0)', 'black'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 24,
+		},
+	],
+});

--- a/lib/rules/color-named/__tests__/index.mjs
+++ b/lib/rules/color-named/__tests__/index.mjs
@@ -577,7 +577,7 @@ testRule({
 			code: 'a { color: var(--foo, #000); }',
 		},
 		{
-			code: 'a { color: --bar(#000); }',
+			code: 'a { color: --foo(#000); }',
 		},	
 	],
 

--- a/lib/rules/color-named/index.mjs
+++ b/lib/rules/color-named/index.mjs
@@ -43,6 +43,7 @@ const rule = (primary, secondaryOptions) => {
 				possible: {
 					ignoreProperties: [isString, isRegExp],
 					ignore: ['inside-function'],
+					ignoreFunctions: [isString, isRegExp],
 				},
 				optional: true,
 			},
@@ -86,6 +87,10 @@ const rule = (primary, secondaryOptions) => {
 					optionsMatches(secondaryOptions, 'ignore', 'inside-function') &&
 					isValueFunction(node)
 				) {
+					return false;
+				}
+
+				if (isValueFunction(node) && optionsMatches(secondaryOptions, 'ignoreFunctions', value)) {
 					return false;
 				}
 

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -94,5 +94,5 @@ a { color: var(--foo, #fff); }
 
 <!-- prettier-ignore -->
 ```css
-a { color: --bar(#fff); }
+a { color: --foo(#fff); }
 ```

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -66,3 +66,33 @@ a { color: rgb(0, 0, 0); }
 ```css
 a { color: rgba(0, 0, 0, 1); }
 ```
+
+## Optional secondary options
+
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
+
+Ignore hex colors within the specified functions.
+
+Given:
+
+```json
+{
+  "color-no-hex": [true, { "ignoreFunctions": ["var", "/^--/"] }]
+}
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a { color: var(--foo, #fff); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: --bar(#fff); }
+```

--- a/lib/rules/color-no-hex/__tests__/index.mjs
+++ b/lib/rules/color-no-hex/__tests__/index.mjs
@@ -161,65 +161,20 @@ testRule({
 	accept: [
 		{
 			code: 'a { color: var(--foo, #fff); }',
-			description: 'hex color as var() fallback',
 		},
 		{
-			code: 'a { color: var(--foo, #ffffff); }',
-			description: 'hex color (longhand) as var() fallback',
-		},
-		{
-			code: 'a { color: var(--foo, #123456aa); }',
-			description: 'hex color (8-digit) as var() fallback',
-		},
-		{
-			code: 'a { color: var(--foo, var(--bar, #fff)); }',
-			description: 'hex color as nested var() fallback',
-		},
-		{
-			code: 'a { color: --bar(#fff); }',
-			description: 'hex color inside function matching /^--/',
-		},
-		{
-			code: 'a { border: var(--border, 1px solid #ffffff); }',
-			description: 'hex color within var() fallback mixed with other values',
-		},
-		{
-			code: 'a { color: calc(var(--foo, #fff) + 10px); }',
-			description: 'ignored var() nested inside a non-ignored function',
-		},
-		{
-			code: 'a { background: url(#abc); }',
-			description: 'url() is still ignored regardless of ignoreFunctions',
+			code: 'a { color: --foo(#fff); }',
 		},
 	],
 
 	reject: [
 		{
 			code: 'a { color: #ffffff; }',
-			description: 'hex color outside any function is still flagged',
 			message: messages.rejected('#ffffff'),
 			line: 1,
 			column: 12,
 			endLine: 1,
 			endColumn: 19,
-		},
-		{
-			code: 'a { color: #fff var(--foo, #000); }',
-			description: 'hex color outside var() is still flagged even when var() fallback is present',
-			message: messages.rejected('#fff'),
-			line: 1,
-			column: 12,
-			endLine: 1,
-			endColumn: 16,
-		},
-		{
-			code: 'a { color: linear-gradient(var(--foo, #fff), #000); }',
-			description: 'hex color outside the ignored var() is still flagged',
-			message: messages.rejected('#000'),
-			line: 1,
-			column: 46,
-			endLine: 1,
-			endColumn: 50,
 		},
 	],
 });

--- a/lib/rules/color-no-hex/__tests__/index.mjs
+++ b/lib/rules/color-no-hex/__tests__/index.mjs
@@ -153,3 +153,73 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: [true, { ignoreFunctions: ['var', /^--/] }],
+
+	accept: [
+		{
+			code: 'a { color: var(--foo, #fff); }',
+			description: 'hex color as var() fallback',
+		},
+		{
+			code: 'a { color: var(--foo, #ffffff); }',
+			description: 'hex color (longhand) as var() fallback',
+		},
+		{
+			code: 'a { color: var(--foo, #123456aa); }',
+			description: 'hex color (8-digit) as var() fallback',
+		},
+		{
+			code: 'a { color: var(--foo, var(--bar, #fff)); }',
+			description: 'hex color as nested var() fallback',
+		},
+		{
+			code: 'a { color: --bar(#fff); }',
+			description: 'hex color inside function matching /^--/',
+		},
+		{
+			code: 'a { border: var(--border, 1px solid #ffffff); }',
+			description: 'hex color within var() fallback mixed with other values',
+		},
+		{
+			code: 'a { color: calc(var(--foo, #fff) + 10px); }',
+			description: 'ignored var() nested inside a non-ignored function',
+		},
+		{
+			code: 'a { background: url(#abc); }',
+			description: 'url() is still ignored regardless of ignoreFunctions',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: #ffffff; }',
+			description: 'hex color outside any function is still flagged',
+			message: messages.rejected('#ffffff'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 19,
+		},
+		{
+			code: 'a { color: #fff var(--foo, #000); }',
+			description: 'hex color outside var() is still flagged even when var() fallback is present',
+			message: messages.rejected('#fff'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 16,
+		},
+		{
+			code: 'a { color: linear-gradient(var(--foo, #fff), #000); }',
+			description: 'hex color outside the ignored var() is still flagged',
+			message: messages.rejected('#000'),
+			line: 1,
+			column: 46,
+			endLine: 1,
+			endColumn: 50,
+		},
+	],
+});

--- a/lib/rules/color-no-hex/index.mjs
+++ b/lib/rules/color-no-hex/index.mjs
@@ -1,10 +1,12 @@
 import valueParser from 'postcss-value-parser';
 
+import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isUrlFunction from '../../utils/isUrlFunction.mjs';
-import { isValueWord } from '../../utils/typeGuards.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
+import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -22,9 +24,20 @@ const meta = {
 const HEX = /^#[\da-z]+$/i;
 
 /** @type {import('stylelint').CoreRules[typeof ruleName]} */
-const rule = (primary) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual: primary });
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{ actual: primary },
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignoreFunctions: [isString, isRegExp],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
@@ -36,16 +49,22 @@ const rule = (primary) => {
 			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
+				const { value } = node;
+
 				if (isUrlFunction(node)) return false;
+
+				if (isValueFunction(node) && optionsMatches(secondaryOptions, 'ignoreFunctions', value)) {
+					return false;
+				}
 
 				if (!isHexColor(node)) return;
 
 				const index = declarationValueIndex(decl) + node.sourceIndex;
-				const endIndex = index + node.value.length;
+				const endIndex = index + value.length;
 
 				report({
 					message: messages.rejected,
-					messageArgs: [node.value],
+					messageArgs: [value],
 					node: decl,
 					index,
 					endIndex,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -569,10 +569,18 @@ declare namespace stylelint {
 		'color-hex-length': CoreRule<'short' | 'long', {}, AutofixMessage>;
 		'color-named': CoreRule<
 			'never' | 'always-where-possible',
-			{ ignoreProperties: OneOrMany<StringOrRegex>; ignore: OneOrMany<'inside-function'> },
+			{
+				ignoreProperties: OneOrMany<StringOrRegex>;
+				ignore: OneOrMany<'inside-function'>;
+				ignoreFunctions: OneOrMany<StringOrRegex>;
+			},
 			AutofixMessage & RejectedMessage<[keyword: string]>
 		>;
-		'color-no-hex': CoreRule<true, {}, RejectedMessage<[hex: string]>>;
+		'color-no-hex': CoreRule<
+			true,
+			{ ignoreFunctions: OneOrMany<StringOrRegex> },
+			RejectedMessage<[hex: string]>
+		>;
 		'color-no-invalid-hex': CoreRule<true, {}, RejectedMessage<[hex: string]>>;
 		'comment-empty-line-before': CoreRule<
 			'always' | 'never',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #9457

> Is there anything in the PR that needs further explanation?

As discussed in the issue, this adds a generic `ignoreFunctions: []` secondary option to both the `color-named` and `color-no-hex` rules, using the `ignoreFunctions` option of `length-zero-no-unit` as a blueprint.

For example:

```json
{
  "color-named": ["never", { "ignoreFunctions": ["var", "/^--/"] }]
}