### PR TITLE
Fix `custom-property-no-missing-var-function` false positives for anchor positioning

### DIFF
--- a/.changeset/anchor-positioning-dashed-idents.md
+++ b/.changeset/anchor-positioning-dashed-idents.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `custom-property-no-missing-var-function` false positives for anchor positioning

--- a/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
@@ -118,6 +118,46 @@ testRule({
 			code: 'a { timeline-scope: --foo; }',
 			description: 'modifies the scope of a named animation timeline',
 		},
+		{
+			code: '@property --foo {} a { anchor-name: --foo; }',
+			description: 'names an anchor element',
+		},
+		{
+			code: '@property --foo {} a { anchor-scope: --foo; }',
+			description: 'limits the scope of an anchor name',
+		},
+		{
+			code: '@property --foo {} a { position-anchor: --foo; }',
+			description: 'refers to an anchor element by name',
+		},
+		{
+			code: '@property --foo {} a { position-try-fallbacks: --foo flip-block; }',
+			description: 'refers to a position option by name',
+		},
+		{
+			code: '@property --foo {} a { position-try: most-width --foo; }',
+			description: 'refers to a position option by name in the shorthand',
+		},
+		{
+			code: '@property --foo {} a { top: anchor(--foo bottom); }',
+			description: 'refers to an anchor element by name in anchor()',
+		},
+		{
+			code: '@property --foo {} a { top: anchor(bottom, 10px); }',
+			description: 'anchor() without an anchor name',
+		},
+		{
+			code: '@property --foo {} a { width: anchor-size(--foo width, 10px); }',
+			description: 'refers to an anchor element by name in anchor-size()',
+		},
+		{
+			code: '@property --foo {} a { top: calc(anchor(--foo bottom) + 10px); }',
+			description: 'refers to an anchor element by name in anchor() within calc',
+		},
+		{
+			code: 'a { --foo: 10px; top: anchor(--bar bottom, var(--foo)); }',
+			description: 'declared custom property in the anchor() fallback',
+		},
 	],
 
 	reject: [
@@ -273,6 +313,33 @@ testRule({
 			endLine: 1,
 			endColumn: 63,
 			description: 'custom property in if() consequent branch missing var() syntax',
+		},
+		{
+			code: 'a { --foo: 10px; top: anchor(--bar bottom, --foo); }',
+			message: messages.rejected('--foo'),
+			line: 1,
+			column: 44,
+			endLine: 1,
+			endColumn: 49,
+			description: 'custom property in the anchor() fallback missing var() syntax',
+		},
+		{
+			code: 'a { --foo: 10px; width: anchor-size(--bar width, --foo); }',
+			message: messages.rejected('--foo'),
+			line: 1,
+			column: 50,
+			endLine: 1,
+			endColumn: 55,
+			description: 'custom property in the anchor-size() fallback missing var() syntax',
+		},
+		{
+			code: 'a { --foo: 10px; anchor-name: --foo; top: --foo; }',
+			message: messages.rejected('--foo'),
+			line: 1,
+			column: 43,
+			endLine: 1,
+			endColumn: 48,
+			description: 'custom property ignored in anchor-name but not in a neighbouring declaration',
 		},
 	],
 });

--- a/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
@@ -119,44 +119,12 @@ testRule({
 			description: 'modifies the scope of a named animation timeline',
 		},
 		{
-			code: '@property --foo {} a { anchor-name: --foo; }',
-			description: 'names an anchor element',
-		},
-		{
-			code: '@property --foo {} a { anchor-scope: --foo; }',
-			description: 'limits the scope of an anchor name',
-		},
-		{
-			code: '@property --foo {} a { position-anchor: --foo; }',
-			description: 'refers to an anchor element by name',
-		},
-		{
-			code: '@property --foo {} a { position-try-fallbacks: --foo flip-block; }',
-			description: 'refers to a position option by name',
-		},
-		{
 			code: '@property --foo {} a { position-try: most-width --foo; }',
 			description: 'refers to a position option by name in the shorthand',
 		},
 		{
 			code: '@property --foo {} a { top: anchor(--foo bottom); }',
 			description: 'refers to an anchor element by name in anchor()',
-		},
-		{
-			code: '@property --foo {} a { top: anchor(bottom, 10px); }',
-			description: 'anchor() without an anchor name',
-		},
-		{
-			code: '@property --foo {} a { width: anchor-size(--foo width, 10px); }',
-			description: 'refers to an anchor element by name in anchor-size()',
-		},
-		{
-			code: '@property --foo {} a { top: calc(anchor(--foo bottom) + 10px); }',
-			description: 'refers to an anchor element by name in anchor() within calc',
-		},
-		{
-			code: 'a { --foo: 10px; top: anchor(--bar bottom, var(--foo)); }',
-			description: 'declared custom property in the anchor() fallback',
 		},
 	],
 
@@ -315,31 +283,32 @@ testRule({
 			description: 'custom property in if() consequent branch missing var() syntax',
 		},
 		{
-			code: 'a { --foo: 10px; top: anchor(--bar bottom, --foo); }',
+			code: 'a { --foo: 10px; --bar: 0; top: anchor(--bar bottom, --foo); }',
 			message: messages.rejected('--foo'),
 			line: 1,
-			column: 44,
+			column: 54,
 			endLine: 1,
-			endColumn: 49,
+			endColumn: 59,
 			description: 'custom property in the anchor() fallback missing var() syntax',
 		},
 		{
-			code: 'a { --foo: 10px; width: anchor-size(--bar width, --foo); }',
+			code: 'a { --foo: 10px; --bar: 0; width: anchor-size(--bar width, --foo); }',
 			message: messages.rejected('--foo'),
 			line: 1,
-			column: 50,
+			column: 60,
 			endLine: 1,
-			endColumn: 55,
+			endColumn: 65,
 			description: 'custom property in the anchor-size() fallback missing var() syntax',
 		},
 		{
-			code: 'a { --foo: 10px; anchor-name: --foo; top: --foo; }',
+			code: 'a { --foo: 10px; --bar: 0; top: anchor(--bar calc(50% + --foo)); }',
 			message: messages.rejected('--foo'),
 			line: 1,
-			column: 43,
+			column: 57,
 			endLine: 1,
-			endColumn: 48,
-			description: 'custom property ignored in anchor-name but not in a neighbouring declaration',
+			endColumn: 62,
+			description:
+				'custom property in the <anchor-side> of anchor() missing var() syntax, declared anchor name ignored',
 		},
 	],
 });

--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -3,6 +3,7 @@ import valueParser from 'postcss-value-parser';
 import { atRuleRegexes, mayIncludeRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
+import isComma from '../../utils/isComma.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -97,19 +98,10 @@ const rule = (primary) => {
 					if (mustDrill) args = child.nodes.slice(1);
 					else return;
 				} else if (name === 'anchor' || name === 'anchor-size') {
-					// The anchor name is a `<dashed-ident>`, but the fallback after the
-					// comma is an ordinary value that may reference custom properties.
-					let foundComma = false;
+					// Only the `<anchor-name>` is ignored
+					const commaIndex = node.nodes.findIndex(isComma);
 
-					node.nodes.forEach((arg) => {
-						if (isValueDiv(arg) && arg.value === ',') {
-							foundComma = true;
-						} else if (foundComma) {
-							check(arg, decl);
-						}
-					});
-
-					return;
+					args = node.nodes.filter((arg, index) => !isAnchorName(arg, index, commaIndex));
 				} else if (name === 'style') {
 					// For style() queries, only exempt the property name (first word before colon)
 					// but still check the value part after the colon
@@ -162,6 +154,18 @@ const rule = (primary) => {
  */
 function isDashedIdent(node) {
 	return isValueWord(node) && node.value.startsWith('--');
+}
+
+/**
+ * Whether a node is the `<anchor-name>` argument of `anchor()` or `anchor-size()`:
+ * a `<dashed-ident>` before the comma that introduces the fallback value.
+ *
+ * @param {Node} node
+ * @param {number} index
+ * @param {number} commaIndex
+ */
+function isAnchorName(node, index, commaIndex) {
+	return isDashedIdent(node) && (commaIndex === -1 || index < commaIndex);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -22,6 +22,8 @@ const meta = {
 
 // Properties that can receive a custom-ident
 const IGNORED_PROPERTIES = new Set([
+	'anchor-name',
+	'anchor-scope',
 	'animation',
 	'animation-name',
 	'animation-timeline',
@@ -37,6 +39,9 @@ const IGNORED_PROPERTIES = new Set([
 	'grid-row-start',
 	'list-style',
 	'list-style-type',
+	'position-anchor',
+	'position-try',
+	'position-try-fallbacks',
 	'timeline-scope',
 	'transition',
 	'transition-property',
@@ -91,6 +96,20 @@ const rule = (primary) => {
 
 					if (mustDrill) args = child.nodes.slice(1);
 					else return;
+				} else if (name === 'anchor' || name === 'anchor-size') {
+					// The anchor name is a `<dashed-ident>`, but the fallback after the
+					// comma is an ordinary value that may reference custom properties.
+					let foundComma = false;
+
+					node.nodes.forEach((arg) => {
+						if (isValueDiv(arg) && arg.value === ',') {
+							foundComma = true;
+						} else if (foundComma) {
+							check(arg, decl);
+						}
+					});
+
+					return;
 				} else if (name === 'style') {
 					// For style() queries, only exempt the property name (first word before colon)
 					// but still check the value part after the colon


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None open. It's the same class of gap as #9163 (`timeline-scope` and `animation-timeline`), this time for the anchor positioning properties and functions.

> Is there anything in the PR that needs further explanation?

### The problem

`anchor-name`, `anchor-scope`, `position-anchor`, `position-try-fallbacks` and `position-try` take a `<dashed-ident>` as a value, not as a custom property reference, and so do the `anchor()` and `anchor-size()` functions. When that name also happens to be a declared custom property, the rule reports it:

<!-- prettier-ignore -->
```css
@property --card {}

.anchor {
	anchor-name: --card;
}

.tooltip {
	position-anchor: --card;
	top: anchor(--card bottom);
}
```

On `main` all three declarations are flagged:

```
4:15 Missing var function for "--card" (custom-property-no-missing-var-function)
8:19 Missing var function for "--card" (custom-property-no-missing-var-function)
9:14 Missing var function for "--card" (custom-property-no-missing-var-function)
```

Wrapping any of them in `var()` would be invalid CSS. From [CSS Anchor Positioning](https://drafts.csswg.org/css-anchor-position-1/):

```
anchor-name: none | <anchor-name>#
<anchor-name> = <dashed-ident>
anchor-scope: none | all | <anchor-name>#
position-anchor: normal | none | auto | <anchor-name> | match-parent
position-try-fallbacks: none | [ [<dashed-ident> || <try-tactic>] | <position-area> ]#
position-try: <'position-try-order'>? <'position-try-fallbacks'>
<anchor()> = anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )
anchor-size() = anchor-size( [<anchor-name> || <anchor-size>]?, <length-percentage>? )
```

The same grammar is in the css-tree syntax data Stylelint already ships, which is why `declaration-property-value-no-unknown` accepts `a { anchor-name: --bar, --qux; }` and rejects `a { anchor-name: foo; }`.

### The cause

`IGNORED_PROPERTIES` (`lib/rules/custom-property-no-missing-var-function/index.mjs:24`) never picked up the anchor positioning properties, and `check()` (`index.mjs:81`) has no branch for `anchor()` or `anchor-size()`, so it walks their arguments and reports the anchor name.

### The fix

Two parts, both following what the rule already does:

- The five properties join `IGNORED_PROPERTIES`, as `container-name`, `view-transition-name` and `timeline-scope` did before them.
- `anchor()` and `anchor-size()` get a branch that skips their arguments up to the comma and keeps checking everything after it, mirroring how `style()` skips the queried property name but still checks the value.

The second part matters because the fallback after the comma is an ordinary `<length-percentage>`, so `top: anchor(--card bottom, --gap)` is still a real missing `var()` and is still reported.

### Cost

For the five properties the rule now skips the whole declaration value, so a missing `var()` inside one of them is no longer reported. That's the trade-off already accepted for the rest of the list, and those properties admit nothing but idents and keywords in practice.

Two related gaps are out of scope here because they belong to other specs: `scroll-timeline-name` / `view-timeline-name` (and their shorthands) and `font-palette` behave the same way. Happy to fold them in if you'd rather have one change.

### Tests

`lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs` goes from 41 to 54 cases.

With the tests in place and only the source reverted to `main`, 9 fail, e.g.

```
● custom-property-no-missing-var-function › accept › true › '@property --foo {} a { anchor-name: --foo; }' › names an anchor element

    expect(received).toEqual(expected) // deep equality

    - Expected  -  1
    + Received  + 13

    - Array []
    + Array [
    +   Object {
    +     "column": 37,
    ...
    +     "text": "Missing var function for \"--foo\" (custom-property-no-missing-var-function)",
```

Two mutations fail disjoint sets, so neither half of the change rides on the other's tests:

- keep the property list, drop the `anchor()` / `anchor-size()` branch: 3 accept cases fail, both new reject cases pass.
- keep the branch but let it skip the whole function: both new reject cases fail, all accept cases pass.

Full suite on this branch: 335 suites, 11168 passed, 14 skipped. `npm run lint` is clean.
