### PR TITLE
Fix `value-keyword-layout-mappings` false positives for `caption-side`

### DIFF
--- a/.changeset/caption-side-layout-mappings.md
+++ b/.changeset/caption-side-layout-mappings.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `value-keyword-layout-mappings` false positives for `caption-side`

--- a/lib/reference/keywords.mjs
+++ b/lib/reference/keywords.mjs
@@ -665,13 +665,6 @@ export const namedColorsKeywords = new Set([
 /** @type {ReadonlyMap<string, ReadonlyMap<string, string>>} */
 export const physicalToFlowRelativeValueKeywordsByProperty = new Map([
 	[
-		'caption-side',
-		new Map([
-			['top', 'block-start'],
-			['bottom', 'block-end'],
-		]),
-	],
-	[
 		'clear',
 		new Map([
 			['left', 'inline-start'],

--- a/lib/rules/value-keyword-layout-mappings/README.md
+++ b/lib/rules/value-keyword-layout-mappings/README.md
@@ -68,11 +68,6 @@ a { text-align: right; }
 a { resize: horizontal; }
 ```
 
-<!-- prettier-ignore -->
-```css
-a { caption-side: top; }
-```
-
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
@@ -88,11 +83,6 @@ a { text-align: end; }
 <!-- prettier-ignore -->
 ```css
 a { resize: inline; }
-```
-
-<!-- prettier-ignore -->
-```css
-a { caption-side: block-start; }
 ```
 
 ### `"physical"`
@@ -124,11 +114,6 @@ a { text-align: start; }
 a { resize: inline; }
 ```
 
-<!-- prettier-ignore -->
-```css
-a { caption-side: block-start; }
-```
-
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
@@ -144,11 +129,6 @@ a { text-align: right; }
 <!-- prettier-ignore -->
 ```css
 a { resize: horizontal; }
-```
-
-<!-- prettier-ignore -->
-```css
-a { caption-side: top; }
 ```
 
 ## Optional secondary options
@@ -167,7 +147,7 @@ Given:
 {
   "value-keyword-layout-mappings": [
     "flow-relative",
-    { "ignoreProperties": ["text-align", "/^caption-/"] }
+    { "ignoreProperties": ["text-align", "/^offset-/"] }
   ]
 }
 ```
@@ -181,7 +161,7 @@ a { text-align: left; }
 
 <!-- prettier-ignore -->
 ```css
-a { caption-side: top; }
+a { offset-anchor: top left; }
 ```
 
 ### `ignoreKeywords`

--- a/lib/rules/value-keyword-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/value-keyword-layout-mappings/__tests__/index.mjs
@@ -16,6 +16,12 @@ testRule({
 		{
 			code: 'a { resize: horizontal; }',
 		},
+		{
+			code: 'a { caption-side: top; }',
+		},
+		{
+			code: 'a { caption-side: block-start; }',
+		},
 	],
 
 	reject: [
@@ -99,6 +105,12 @@ testRule({
 			code: 'a { float: var(--left); }',
 		},
 		{
+			code: 'a { caption-side: top; }',
+		},
+		{
+			code: 'a { caption-side: block-end; }',
+		},
+		{
 			code: 'a { text-align: -webkit-left; }',
 		},
 		{
@@ -168,6 +180,9 @@ testRule({
 	accept: [
 		{
 			code: 'a { float: inline-start; }',
+		},
+		{
+			code: 'a { caption-side: top; }',
 		},
 	],
 
@@ -351,11 +366,14 @@ testRule({
 
 testRule({
 	ruleName,
-	config: ['flow-relative', { ignoreProperties: ['text-align', /^caption-/] }],
+	config: ['flow-relative', { ignoreProperties: ['text-align', /^offset-/] }],
 
 	accept: [
 		{
 			code: 'a { text-align: left; }',
+		},
+		{
+			code: 'a { offset-anchor: top left; }',
 		},
 	],
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None open. It completes #9289, which was only partly applied by #9293.

> Is there anything in the PR that needs further explanation?

### The problem

#9289 concluded that `caption-side` should be removed from `value-keyword-layout-mappings`, and #9293 was merged as "Fixed: `value-keyword-layout-mappings` false positives for `caption-side`". The false positives are still there on `main`:

<!-- prettier-ignore -->
```css
/* "flow-relative" */
a { caption-side: top; }    /* Disallowed physical keyword "top" */
a { caption-side: bottom; } /* Disallowed physical keyword "bottom" */
```

<!-- prettier-ignore -->
```css
/* "physical" */
a { caption-side: block-start; } /* Disallowed flow-relative keyword "block-start" */
a { caption-side: block-end; }   /* Disallowed flow-relative keyword "block-end" */
```

The `top` report also survives when `languageOptions.directionality` is configured, so `caption-side` is now the one property this rule reports but never fixes.

### The cause

#9293 removed `['caption-side', 'side']` from `directionalMappingKinds` in the rule, but left the `caption-side` entry in `physicalToFlowRelativeValueKeywordsByProperty` (`lib/reference/keywords.mjs:667`). That map is what builds `propertyRegexes.layoutMappings` and the `disallowedKeywordsByProperty` lookup, so `root.walkDecls` still visits `caption-side` and still reports. Dropping the entry from `directionalMappingKinds` only removed the autofix half: `buildDirectionalMap` now returns an empty mapping for the property, `expectedKeyword` is `undefined`, and the rule falls through to the unfixable `rejected` branch (`lib/rules/value-keyword-layout-mappings/index.mjs:194`).

Every `caption-side` test case was deleted in #9293 rather than moved to `accept`, so nothing pinned the remaining behaviour.

### The spec

[CSS Logical Properties and Values Level 1, 2.1](https://drafts.csswg.org/css-logical-1/#caption-side) backs the decision made in #9289:

> **Name:** caption-side
> **New values:** `inline-start | inline-end`
>
> These two values are added only for implementations that support `left` and `right` values for `caption-side`. The `left` and `right` values themselves are defined to be line-relative.
>
> The existing `top` and `bottom` values are idiosyncratically redefined as assigning to the block-start and block-end sides of the table, respectively.

So `block-start` and `block-end` are not `caption-side` values at all, and `top` and `bottom` already are the block-axis values. There is nothing physical about `caption-side: top` to report, and nothing to rewrite it to.

### The fix

Drop the `caption-side` entry from `physicalToFlowRelativeValueKeywordsByProperty`, which is the only thing that made the rule visit the property. `top`, `bottom`, `block-start` and `block-end` stay in the keyword regexes via `offset-anchor` and `offset-position`, so no other property changes behaviour.

The rule's README loses its `caption-side` examples, and the `ignoreProperties` example switches from `/^caption-/` to `/^offset-/` so that it still matches a property the rule handles. The same stale `/^caption-/` was in the tests.

### Out of scope

The spec does define `inline-start | inline-end` as flow-relative counterparts of `caption-side: left | right`, so a `left` -> `inline-start` mapping could be added later. That is a new mapping rather than a fix, and #9289 asked for removal "for now", so it is not in this PR.

### Tests

`lib/rules/value-keyword-layout-mappings/__tests__/index.mjs` goes from 41 to 46 cases: `caption-side` is accepted for both primary options and under a configured `directionality`, plus one case for the `/^offset-/` `ignoreProperties` example.

With the tests in place and only `lib/reference/keywords.mjs` reverted to `main`, 3 fail:

```
● value-keyword-layout-mappings › accept › [ 'physical' ] › 'a { caption-side: block-start; }'
    + "text": "Disallowed flow-relative keyword \"block-start\" (value-keyword-layout-mappings)",

● value-keyword-layout-mappings › accept › [ 'flow-relative' ] › 'a { caption-side: top; }'
    + "text": "Disallowed physical keyword \"top\" (value-keyword-layout-mappings)",

● value-keyword-layout-mappings › accept › [ 'flow-relative' ] › 'a { caption-side: top; }'
    + "text": "Disallowed physical keyword \"top\" (value-keyword-layout-mappings)",
```

Full suite on this branch: 335 suites, 11202 passed, 14 skipped. `npm run lint` is clean.
