### PR TITLE
Refactor to replace `fastest-levenshtein`

### DIFF
--- a/lib/reportUnknownRuleNames.mjs
+++ b/lib/reportUnknownRuleNames.mjs
@@ -1,6 +1,5 @@
-import { distance } from 'fastest-levenshtein';
-
 import { SEVERITY_ERROR } from './constants.mjs';
+import levenshteinDistance from './utils/levenshteinDistance.mjs';
 import rules from './rules/index.mjs';
 
 const MAX_LEVENSHTEIN_DISTANCE = 6;
@@ -18,10 +17,10 @@ function extractSuggestions(ruleName) {
 	}
 
 	for (const existRuleName of Object.keys(rules)) {
-		const dist = distance(existRuleName, ruleName);
+		const distance = levenshteinDistance(existRuleName, ruleName);
 
-		if (dist <= MAX_LEVENSHTEIN_DISTANCE) {
-			suggestions[dist - 1].push(existRuleName);
+		if (distance <= MAX_LEVENSHTEIN_DISTANCE) {
+			suggestions[distance - 1].push(existRuleName);
 		}
 	}
 

--- a/lib/utils/__tests__/levenshteinDistance.test.mjs
+++ b/lib/utils/__tests__/levenshteinDistance.test.mjs
@@ -1,0 +1,20 @@
+import levenshteinDistance from '../levenshteinDistance.mjs';
+
+test('levenshteinDistance', () => {
+	expect(levenshteinDistance('', '')).toBe(0);
+	expect(levenshteinDistance('', 'foo')).toBe(3);
+	expect(levenshteinDistance('foo', '')).toBe(3);
+	expect(levenshteinDistance('foo', 'foo')).toBe(0);
+	expect(levenshteinDistance('foo', 'fo')).toBe(1);
+	expect(levenshteinDistance('fo', 'foo')).toBe(1);
+	expect(levenshteinDistance('foo', 'fob')).toBe(1);
+	expect(levenshteinDistance('ab', 'ba')).toBe(2);
+	expect(levenshteinDistance('kitten', 'sitting')).toBe(3);
+	expect(levenshteinDistance('sitting', 'kitten')).toBe(3);
+	expect(levenshteinDistance('color-namd', 'color-named')).toBe(1);
+});
+
+test('levenshteinDistance compares UTF-16 code units', () => {
+	expect(levenshteinDistance('😀', '')).toBe(2);
+	expect(levenshteinDistance('😀', '😁')).toBe(1);
+});

--- a/lib/utils/checkInvalidCLIOptions.mjs
+++ b/lib/utils/checkInvalidCLIOptions.mjs
@@ -1,7 +1,8 @@
 import { EOL } from 'node:os';
 
-import { distance } from 'fastest-levenshtein';
 import picocolors from 'picocolors';
+
+import levenshteinDistance from './levenshteinDistance.mjs';
 
 const { cyan, red } = picocolors;
 
@@ -32,7 +33,7 @@ const suggest = (all, invalid) => {
 	const maxThreshold = 10;
 
 	for (let threshold = 1; threshold <= maxThreshold; threshold++) {
-		const suggestion = all.find((option) => distance(option, invalid) <= threshold);
+		const suggestion = all.find((option) => levenshteinDistance(option, invalid) <= threshold);
 
 		if (suggestion) {
 			return suggestion;

--- a/lib/utils/levenshteinDistance.mjs
+++ b/lib/utils/levenshteinDistance.mjs
@@ -1,0 +1,35 @@
+/**
+ * Compute the Levenshtein distance between two strings: the minimum number of
+ * single-character insertions, deletions, and substitutions that turn one into
+ * the other. Characters are compared as UTF-16 code units.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export default function levenshteinDistance(a, b) {
+	// Each entry holds the distance from the current prefix of `a` to a non-empty
+	// prefix of `b`. The row is updated in place, one character of `a` at a time.
+	const row = Array.from({ length: b.length }, (_, index) => index + 1);
+
+	let distance = b.length;
+
+	for (let i = 1; i <= a.length; i++) {
+		const code = a.charCodeAt(i - 1);
+		let diagonal = i - 1;
+		let left = i;
+
+		for (const [index, above] of row.entries()) {
+			const substitutionCost = code === b.charCodeAt(index) ? 0 : 1;
+			const current = Math.min(above + 1, left + 1, diagonal + substitutionCost);
+
+			row[index] = current;
+			diagonal = above;
+			left = current;
+		}
+
+		distance = left;
+	}
+
+	return distance;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "css-tree": "^3.2.1",
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
-        "fastest-levenshtein": "^1.0.16",
         "file-entry-cache": "^11.1.5",
         "global-modules": "^2.0.0",
         "globby": "^16.2.4",
@@ -5356,14 +5355,6 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
-      }
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "engines": {
-        "node": ">= 4.9.1"
       }
     },
     "node_modules/fastq": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "css-tree": "^3.2.1",
     "debug": "^4.4.3",
     "fast-glob": "^3.3.3",
-    "fastest-levenshtein": "^1.0.16",
     "file-entry-cache": "^11.1.5",
     "global-modules": "^2.0.0",
     "globby": "^16.2.4",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of our efforts to reduce dependencies.

> Is there anything in the PR that needs further explanation?

[`fastest-levenshtein`](https://npmx.dev/package/fastest-levenshtein) belongs to a dormant single-owner account.

The PR replace it with a simple Levenshtein algorithm.

Time for one scan of all 150 rules:
- package: 0.060 ms
- inlined: 1.287 ms

Negligible performance hit for a seldom-used path: an invalid rule name or option.

Base is `v18`.

