### PR TITLE
Fix custom-property-no-missing-var-function false positives for recently introduced properties

### DIFF
--- a/.changeset/custom-property-dashed-ident-grammar.md
+++ b/.changeset/custom-property-dashed-ident-grammar.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `custom-property-no-missing-var-function` false positives for `scroll-timeline-name` and `view-timeline-name`

--- a/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
@@ -123,6 +123,34 @@ testRule({
 			description: 'refers to a position option by name in the shorthand',
 		},
 		{
+			code: '@property --foo {} a { scroll-timeline-name: --foo; }',
+			description: 'ignore scroll-timeline-name which accepts a dashed-ident',
+		},
+		{
+			code: '@property --foo {} a { view-timeline-name: --foo; }',
+			description: 'ignore view-timeline-name which accepts a dashed-ident',
+		},
+		{
+			code: '@property --foo {} a { SCROLL-TIMELINE-NAME: --foo; }',
+			description: 'ignore scroll-timeline-name with a mixed-case property name',
+		},
+		{
+			code: '@property --foo {} a { scroll-timeline: --foo; }',
+			description: 'ignore scroll-timeline shorthand which accepts a dashed-ident name',
+		},
+		{
+			code: '@property --foo {} a { view-timeline: --foo; }',
+			description: 'ignore view-timeline shorthand which accepts a dashed-ident name',
+		},
+		{
+			code: '@property --foo {} a { scroll-timeline: --foo block; }',
+			description: 'ignore scroll-timeline shorthand with an axis',
+		},
+		{
+			code: '@property --foo {} a { view-timeline: --foo inline; }',
+			description: 'ignore view-timeline shorthand with an axis',
+		},
+		{
 			code: '@property --foo {} a { top: anchor(--foo bottom); }',
 			description: 'refers to an anchor element by name in anchor()',
 		},

--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -20,35 +20,41 @@ const meta = {
 };
 
 /** @import { Node } from 'postcss-value-parser' */
+/** @import { Lexer } from 'css-tree' */
 
-// Properties that can receive a custom-ident
-const IGNORED_PROPERTIES = new Set([
-	'anchor-name',
-	'anchor-scope',
-	'animation',
-	'animation-name',
-	'animation-timeline',
-	'container-name',
-	'counter-increment',
-	'counter-reset',
-	'counter-set',
-	'grid-column',
-	'grid-column-end',
-	'grid-column-start',
-	'grid-row',
-	'grid-row-end',
-	'grid-row-start',
-	'list-style',
-	'list-style-type',
-	'position-anchor',
-	'position-try',
-	'position-try-fallbacks',
-	'timeline-scope',
-	'transition',
-	'transition-property',
-	'view-transition-name',
-	'will-change',
-]);
+/**
+ * Probe used to find properties whose grammar accepts a `<dashed-ident>`
+ * as a complete value, rather than a custom property reference via `var()`.
+ */
+const DASHED_IDENT_PROBE = '--foo';
+
+/** @type {WeakMap<Lexer, Set<string>>} */
+const ignoredPropertiesByLexer = new WeakMap();
+
+/**
+ * Properties that can receive a `<dashed-ident>` / custom-ident, derived from
+ * the css-tree lexer so the list stays in sync with CSS grammar.
+ *
+ * @param {Lexer} lexer
+ * @returns {Set<string>}
+ */
+function getIgnoredProperties(lexer) {
+	let ignoredProperties = ignoredPropertiesByLexer.get(lexer);
+
+	if (!ignoredProperties) {
+		// css-tree's published Lexer types omit the syntax dictionaries.
+		const { properties } = /** @type {Lexer & { properties: Record<string, unknown> }} */ (lexer);
+
+		ignoredProperties = new Set(
+			Object.keys(properties).filter(
+				(property) => !lexer.matchProperty(property, DASHED_IDENT_PROBE).error,
+			),
+		);
+		ignoredPropertiesByLexer.set(lexer, ignoredProperties);
+	}
+
+	return ignoredProperties;
+}
 
 /** @type {import('stylelint').CoreRules[typeof ruleName]} */
 const rule = (primary) => {
@@ -56,6 +62,9 @@ const rule = (primary) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) return;
+
+		const lexer = /** @type {Lexer} */ (result.stylelint.lexer);
+		const ignoredProperties = getIgnoredProperties(lexer);
 
 		/** @type {Set<string>} */
 		const knownCustomProperties = new Set();
@@ -73,7 +82,7 @@ const rule = (primary) => {
 
 			if (!mayIncludeRegexes.customProperty.test(value)) return;
 
-			if (IGNORED_PROPERTIES.has(prop.toLowerCase())) return;
+			if (ignoredProperties.has(prop.toLowerCase())) return;
 
 			valueParser(value).nodes.forEach((childNode) => {
 				check(childNode, decl);


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/9469

> Is there anything in the PR that needs further explanation?

`custom-property-no-missing-var-function` skipped properties that accept a `<dashed-ident>` via a hardcoded `IGNORED_PROPERTIES` Set. That list keeps falling behind the CSS specs; `scroll-timeline-name` / `view-timeline-name` (and their shorthands) were the latest gap after the anchor-positioning additions in #9466.

This replaces the hand-maintained Set with the css-tree lexer Stylelint already builds (`result.stylelint.lexer`). Properties whose grammar accepts `--foo` as a complete value are ignored. That matches the approach @ybiquitous approved on the issue. The result is cached per lexer instance so `languageOptions.syntax` extensions are respected.

New tests cover scroll/view-timeline names and shorthands (including mixed-case). Existing accept/reject cases stay green.

Drafted with Cursor (Grok); reviewed before opening.
