### PR TITLE
Change the CLI to parse arguments with `node:util.parseArgs`

### DIFF
--- a/.changeset/upset-kings-press.md
+++ b/.changeset/upset-kings-press.md
@@ -1,0 +1,5 @@
+---
+"stylelint": major
+---
+
+Changed: the CLI to parse arguments with `node:util.parseArgs`

--- a/docs/migration-guide/to-18.md
+++ b/docs/migration-guide/to-18.md
@@ -13,6 +13,7 @@ We've removed:
 And changed:
 
 - TypeScript config files to be loaded by Node.js's built-in type stripping
+- the CLI to parse arguments with Node.js's built-in parser
 
 ### Removed support for end-of-life and older versions of Node.js
 
@@ -99,4 +100,29 @@ For example:
 ```diff ts
 -import { Config } from "stylelint";
 +import type { Config } from "stylelint";
+```
+
+### Changed the CLI to parse arguments with Node.js's built-in parser
+
+We've changed the CLI to parse arguments with Node.js's built-in [`parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig) utility rather than the `meow` package.
+
+If you separate the value of `--fix` with a space, you should attach it with `=` instead, as the CLI now reads a separate word as an input path:
+
+```diff shell
+-stylelint "**/*.css" --fix lax
++stylelint "**/*.css" --fix=lax
+```
+
+If you attach the value of a short flag with `=`, you should separate it with a space instead:
+
+```diff shell
+-stylelint "**/*.css" -c=stylelint.config.mjs
++stylelint "**/*.css" -c stylelint.config.mjs
+```
+
+If you use camelCase flags, you should update them to their kebab-case names:
+
+```diff shell
+-stylelint "**/*.css" --ignorePath .gitignore --allowEmptyInput
++stylelint "**/*.css" --ignore-path .gitignore --allow-empty-input
 ```

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -72,7 +72,7 @@ Compute edit information for fixable problems. [More info](options.md#computeedi
 
 Specify the formatter to format your results. [More info](options.md#formatter).
 
-### `--globbyOptions, --go`
+### `--globby-options, --go`
 
 Options in JSON format passed to [globby](https://github.com/sindresorhus/globby). [More info](options.md#globbyoptions).
 
@@ -134,7 +134,7 @@ Accept stdin input even if it is empty.
 
 ### `--suppress`
 
-Suppress problems that have the severity of `error` and record them in a file. [More info](suppressions.md#--suppress-rule).
+Suppress problems that have the severity of `error` and record them in a file. [More info](suppressions.md#--suppressrule).
 
 ### `--suppress-location`
 

--- a/docs/user-guide/suppressions.md
+++ b/docs/user-guide/suppressions.md
@@ -5,11 +5,11 @@
 
 Turning on a rule with the severity of `error` can be difficult when an established codebase already contains many problems that can't be auto-fixed. You can suppress those legacy problems so the rule is enforced only for new code, and then clear the backlog at your own pace.
 
-## `--suppress [<rule>]`
+## `--suppress[=<rule>]`
 
 Suppress problems that have the severity of `error` and record them in a file.
 
-If no rule is specified, all problems are suppressed. Otherwise, only problems with the given rules are suppressed, e.g., `--suppress rule1 --suppress rule2`.
+If no rule is specified, all problems are suppressed. Otherwise, only problems with the given rules are suppressed, e.g., `--suppress=rule1 --suppress=rule2`.
 
 Subsequent runs without the `--suppress` flag will not report these problems, unless there are more problems for the same rule in the same file.
 

--- a/lib/__tests__/__snapshots__/cli.test.mjs.snap
+++ b/lib/__tests__/__snapshots__/cli.test.mjs.snap
@@ -51,7 +51,7 @@ exports[`CLI --help 1`] = `
       A pattern of files to ignore (in addition to those in ".stylelintignore").
       Multiple can be set.
 
-    --fix [<mode>]
+    --fix[=<mode>]
 
       Automatically fix problems of certain rules. The modes are as follows:
 
@@ -173,10 +173,11 @@ exports[`CLI --help 1`] = `
 
       When a glob pattern matches no files, the process will exit without throwing an error.
 
-    --suppress [<rule>]
+    --suppress[=<rule>]
+
       Suppress problems and record them in a file. If no rule is specified,
       all problems are suppressed. Otherwise, only problems with the given
-      rules are suppressed, e.g., "--suppress rule1 --suppress rule2".
+      rules are suppressed, e.g., "--suppress=rule1 --suppress=rule2".
       See also "--suppress-location".
 
     --suppress-location <path>

--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -1,5 +1,3 @@
-/* eslint no-console: off */
-
 import * as fs from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
@@ -41,6 +39,16 @@ describe('buildCLI', () => {
 		});
 	});
 
+	it('optionNames', () => {
+		expect(buildCLI(['--fix', '-c', 'foo', '--cei', '--foo', '-x']).optionNames).toEqual([
+			'fix',
+			'config',
+			'cei',
+			'foo',
+			'x',
+		]);
+	});
+
 	it('flags.allowEmptyInput', () => {
 		expect(buildCLI(['--allow-empty-input']).flags.allowEmptyInput).toBe(true);
 		expect(buildCLI(['--aei']).flags.allowEmptyInput).toBe(true);
@@ -72,7 +80,7 @@ describe('buildCLI', () => {
 
 	it('flags.config', () => {
 		expect(buildCLI(['--config=/path/to/file']).flags.config).toBe('/path/to/file');
-		expect(buildCLI(['-c=/path/to/file']).flags.config).toBe('/path/to/file');
+		expect(buildCLI(['--config']).flags.config).toBeUndefined();
 	});
 
 	it('flags.configBasedir', () => {
@@ -104,6 +112,14 @@ describe('buildCLI', () => {
 		expect(buildCLI(['--fix true']).flags.fix).toBeUndefined();
 		expect(buildCLI(['--fix false']).flags.fix).toBeUndefined();
 		expect(buildCLI(['--fix unknown']).flags.fix).toBeUndefined();
+		expect(buildCLI(['--fix', 'lax', 'a.css'])).toMatchObject({
+			flags: { fix: '' },
+			input: ['lax', 'a.css'],
+		});
+		expect(buildCLI(['--fix', 'a.css', 'b.css'])).toMatchObject({
+			flags: { fix: '' },
+			input: ['a.css', 'b.css'],
+		});
 	});
 
 	it('flags.validate', () => {
@@ -201,9 +217,10 @@ describe('buildCLI', () => {
 	});
 
 	it('flags.suppress', () => {
-		expect(buildCLI(['--suppress']).flags.suppress).toEqual([]);
+		expect(buildCLI(['--suppress']).flags.suppress).toEqual(['']);
 		expect(buildCLI(['--suppress=foo']).flags.suppress).toEqual(['foo']);
 		expect(buildCLI(['--suppress=foo', '--suppress=bar']).flags.suppress).toEqual(['foo', 'bar']);
+		expect(buildCLI(['--suppress', '--fix']).flags).toMatchObject({ suppress: [''], fix: '' });
 	});
 
 	it('flags.suppressLocation', () => {
@@ -213,10 +230,8 @@ describe('buildCLI', () => {
 
 describe('CLI', () => {
 	beforeEach(() => {
-		jest.spyOn(process, 'exit').mockImplementation(() => {});
 		jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
 		jest.spyOn(process.stderr, 'write').mockImplementation(() => {});
-		jest.spyOn(console, 'log').mockImplementation(() => {});
 		jest.spyOn(console, 'error').mockImplementation(() => {});
 	});
 
@@ -240,10 +255,10 @@ describe('CLI', () => {
 
 		await cli([]);
 
-		expect(process.exit).toHaveBeenCalledWith(0);
+		expect(process.exitCode).toBeUndefined();
 
-		expect(console.log).toHaveBeenCalledTimes(1);
-		expect(console.log).toHaveBeenCalledWith(
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		expect(process.stdout.write).toHaveBeenCalledWith(
 			expect.stringContaining('Usage: stylelint [input] [options]'),
 		);
 	});
@@ -251,19 +266,19 @@ describe('CLI', () => {
 	it('--help', async () => {
 		await cli(['--help']);
 
-		expect(process.exit).toHaveBeenCalledWith(0);
+		expect(process.exitCode).toBeUndefined();
 
-		expect(console.log).toHaveBeenCalledTimes(1);
-		expect(console.log.mock.calls[0][0]).toMatchSnapshot();
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		expect(process.stdout.write.mock.calls[0][0]).toMatchSnapshot();
 	});
 
 	it('--version', async () => {
 		await cli(['--version']);
 
-		expect(process.exit).toHaveBeenCalledWith(0);
+		expect(process.exitCode).toBeUndefined();
 
-		expect(console.log).toHaveBeenCalledTimes(1);
-		expect(console.log).toHaveBeenCalledWith(expect.stringContaining(pkg.version));
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining(pkg.version));
 	});
 
 	it('--print-config', async () => {
@@ -632,14 +647,13 @@ describe('CLI', () => {
 		expect(await fs.readFile(cssFile2, 'utf8')).toBe('b { top: 0 }');
 	});
 
-	it('applies "--fix lax" to a given file and shows no error messages', async () => {
+	it('applies --fix=lax to a given file and shows no error messages', async () => {
 		const cssFile = path.join(cssTmpDir, 'fix-test.css');
 
 		await fs.writeFile(cssFile, 'a { top: 0px } a {');
 
 		await cli([
-			'--fix',
-			'lax',
+			'--fix=lax',
 			cssFile,
 			'--config',
 			fixturesPath('config-length-zero-no-unit-true.json'),
@@ -777,6 +791,18 @@ describe('CLI', () => {
 		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringMatching(/--foo/));
+	});
+
+	it('exits with an error message when a camelCase flag is specified', async () => {
+		await cli(['--allowEmptyInput']);
+
+		expect(process.exitCode).toBe(EXIT_CODE_INVALID_USAGE);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
+			expect.stringMatching(/--allowEmptyInput.*--allow-empty-input/),
+		);
 	});
 
 	it('--compute-edit-info includes editInfo in warnings', async () => {

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -1,11 +1,11 @@
 import { isAbsolute, join, resolve } from 'node:path';
 import { EOL } from 'node:os';
+import { parseArgs } from 'node:util';
 import process from 'node:process';
+import { readFileSync } from 'node:fs';
 
 import picocolors from 'picocolors';
 const { dim, red } = picocolors;
-
-import meow from 'meow';
 
 import { isBoolean, isNumber, isObject, isPlainObject, isString } from './utils/validateTypes.mjs';
 import checkInvalidCLIOptions from './utils/checkInvalidCLIOptions.mjs';
@@ -19,212 +19,226 @@ import writeOutputFile from './writeOutputFile.mjs';
 
 import {
 	DEFAULT_CACHE_LOCATION,
-	DEFAULT_FIX_MODE,
 	DEFAULT_FORMATTER,
 	DEFAULT_IGNORE_FILENAME,
 	DEFAULT_SUPPRESSION_FILENAME,
 	EXIT_CODE_FATAL_ERROR,
 	EXIT_CODE_INVALID_USAGE,
 	EXIT_CODE_LINT_PROBLEM,
-	EXIT_CODE_SUCCESS,
 } from './constants.mjs';
 import normalizeFixMode from './utils/normalizeFixMode.mjs';
 
+/** @import { ParseArgsConfig } from 'node:util' */
+
+/** @typedef {NonNullable<ParseArgsConfig['options']>[string]} ParseArgsOption */
+
 const helpText = `
-    Usage: stylelint [input] [options]
+  Usage: stylelint [input] [options]
 
-    Input: Files(s), glob(s), or nothing to use stdin.
+  Input: Files(s), glob(s), or nothing to use stdin.
 
-      If an input argument is wrapped in quotation marks, it will be passed to
-      globby for cross-platform glob support. "node_modules" are always ignored.
-      You can also pass no input and use stdin, instead.
+    If an input argument is wrapped in quotation marks, it will be passed to
+    globby for cross-platform glob support. "node_modules" are always ignored.
+    You can also pass no input and use stdin, instead.
 
-    Options:
+  Options:
 
-      --config, -c <path_or_module>
+    --config, -c <path_or_module>
 
-        A path to a specific configuration file (JSON, YAML, CommonJS, or ES module),
-        or a module name in "node_modules" that points to one. If no argument is
-        provided, Stylelint will search for configuration files in the following
-        places, in this order:
+      A path to a specific configuration file (JSON, YAML, CommonJS, or ES module),
+      or a module name in "node_modules" that points to one. If no argument is
+      provided, Stylelint will search for configuration files in the following
+      places, in this order:
 
-          - a "stylelint" property in "package.json"
-          - a ".stylelintrc" file
-          - a ".stylelintrc.{cjs,mjs,js,ts,json,yaml,yml}" file
-          - a "stylelint.config.{cjs,mjs,js,ts}" file
+        - a "stylelint" property in "package.json"
+        - a ".stylelintrc" file
+        - a ".stylelintrc.{cjs,mjs,js,ts,json,yaml,yml}" file
+        - a "stylelint.config.{cjs,mjs,js,ts}" file
 
-        The search will begin in the working directory and move up the directory
-        tree until a configuration file is found.
+      The search will begin in the working directory and move up the directory
+      tree until a configuration file is found.
 
-      --config-basedir <path>
+    --config-basedir <path>
 
-        An absolute path to the directory that relative paths defining "extends",
-        "plugins", and "customSyntax" are *relative to*. Only necessary if these
-        values are relative paths.
+      An absolute path to the directory that relative paths defining "extends",
+      "plugins", and "customSyntax" are *relative to*. Only necessary if these
+      values are relative paths.
 
-      --print-config
+    --print-config
 
-        Print the configuration for the given input file path. Globs are unsupported.
+      Print the configuration for the given input file path. Globs are unsupported.
 
-      --ignore-path, -i <path>
+    --ignore-path, -i <path>
 
-        A path to a file containing patterns that describe files to ignore. The
-        path can be absolute or relative to "process.cwd()". You can repeat the
-        option to provide multiple paths. By default, Stylelint looks for
-        "${DEFAULT_IGNORE_FILENAME}" in "process.cwd()". Multiple can be set.
+      A path to a file containing patterns that describe files to ignore. The
+      path can be absolute or relative to "process.cwd()". You can repeat the
+      option to provide multiple paths. By default, Stylelint looks for
+      "${DEFAULT_IGNORE_FILENAME}" in "process.cwd()". Multiple can be set.
 
-      --ignore-pattern, --ip <pattern>
+    --ignore-pattern, --ip <pattern>
 
-        A pattern of files to ignore (in addition to those in "${DEFAULT_IGNORE_FILENAME}").
-        Multiple can be set.
+      A pattern of files to ignore (in addition to those in "${DEFAULT_IGNORE_FILENAME}").
+      Multiple can be set.
 
-      --fix [<mode>]
+    --fix[=<mode>]
 
-        Automatically fix problems of certain rules. The modes are as follows:
+      Automatically fix problems of certain rules. The modes are as follows:
 
-          strict       only fixing when there are no syntax errors (default)
-          lax          attempting to fix as much as possible even with syntax errors
+        strict       only fixing when there are no syntax errors (default)
+        lax          attempting to fix as much as possible even with syntax errors
 
-      --compute-edit-info, --cei
+    --compute-edit-info, --cei
 
-        Compute edit information for fixable problems.
+      Compute edit information for fixable problems.
 
-      --custom-syntax <name_or_path>
+    --custom-syntax <name_or_path>
 
-        A module name or path to a JS file exporting a PostCSS-compatible syntax.
+      A module name or path to a JS file exporting a PostCSS-compatible syntax.
 
-      --stdin
+    --stdin
 
-        Accept stdin input even if it is empty.
+      Accept stdin input even if it is empty.
 
-      --stdin-filename <name>
+    --stdin-filename <name>
 
-        A filename to assign stdin input.
+      A filename to assign stdin input.
 
-      --ignore-disables, --id
+    --ignore-disables, --id
 
-        Ignore "stylelint-disable" comments.
+      Ignore "stylelint-disable" comments.
 
-      --disable-default-ignores, --di
+    --disable-default-ignores, --di
 
-        Allow linting of "node_modules".
+      Allow linting of "node_modules".
 
-      --[no-]cache
+    --[no-]cache
 
-        Store the info about processed files in order to only operate on the
-        changed ones the next time you run Stylelint. By default, the cache is
-        stored in "${DEFAULT_CACHE_LOCATION}". To adjust this, use "--cache-location".
-        Cache is disabled by default.
+      Store the info about processed files in order to only operate on the
+      changed ones the next time you run Stylelint. By default, the cache is
+      stored in "${DEFAULT_CACHE_LOCATION}". To adjust this, use "--cache-location".
+      Cache is disabled by default.
 
-      --cache-location <path>
+    --cache-location <path>
 
-        A path to a file or directory to be used for the cache location. If a
-        directory is specified, a cache file will be created inside the specified
-        folder, with a name derived from a hash of the current working directory.
+      A path to a file or directory to be used for the cache location. If a
+      directory is specified, a cache file will be created inside the specified
+      folder, with a name derived from a hash of the current working directory.
 
-        If the directory for the cache does not exist, make sure you add a trailing "/"
-        on *nix systems or "\\" on Windows. Otherwise the path will be assumed to
-        be a file.
+      If the directory for the cache does not exist, make sure you add a trailing "/"
+      on *nix systems or "\\" on Windows. Otherwise the path will be assumed to
+      be a file.
 
-      --cache-strategy <strategy>
+    --cache-strategy <strategy>
 
-        A strategy for the cache to use for detecting changed files. Either one of:
+      A strategy for the cache to use for detecting changed files. Either one of:
 
-          metadata     by metadata of a file (default)
-          content      by content of a file
+        metadata     by metadata of a file (default)
+        content      by content of a file
 
-        The "content" strategy can be useful in cases where the modification time
-        of your files changes even if their contents have not. For example, this can
-        happen during git operations like "git clone" because git does not track file
-        modification time.
+      The "content" strategy can be useful in cases where the modification time
+      of your files changes even if their contents have not. For example, this can
+      happen during git operations like "git clone" because git does not track file
+      modification time.
 
-      --formatter, -f <formatter>
+    --formatter, -f <formatter>
 
-        An output formatter. The variants are as follows:
+      An output formatter. The variants are as follows:
 
-          string       human-readable strings (default)
-          compact      similar to ESLint's compact formatter
-          json         JSON format
-          tap          TAP format
-          unix         C compiler-like format
-          verbose      extend "string" to include a file list and a tally
+        string       human-readable strings (default)
+        compact      similar to ESLint's compact formatter
+        json         JSON format
+        tap          TAP format
+        unix         C compiler-like format
+        verbose      extend "string" to include a file list and a tally
 
-      --custom-formatter <path_or_module>
+    --custom-formatter <path_or_module>
 
-        A path to a JS file or module name exporting a custom formatting function.
+      A path to a JS file or module name exporting a custom formatting function.
 
-      --quiet, -q
+    --quiet, -q
 
-        Only register problems for rules with an "error"-level severity (ignore
-        "warning"-level).
+      Only register problems for rules with an "error"-level severity (ignore
+      "warning"-level).
 
-      --quiet-deprecation-warnings
+    --quiet-deprecation-warnings
 
-        Ignore deprecations warnings.
+      Ignore deprecations warnings.
 
-      --[no-]color
+    --[no-]color
 
-        Force enabling/disabling of color.
+      Force enabling/disabling of color.
 
-      --[no-]validate
+    --[no-]validate
 
-        Force enable/disable the validation of the rules' options.
+      Force enable/disable the validation of the rules' options.
 
-      --report-needless-disables, --rd
+    --report-needless-disables, --rd
 
-        Also report errors for "stylelint-disable" comments that are not blocking
-        a lint warning. The process will exit with code ${EXIT_CODE_LINT_PROBLEM} if needless disables are found.
+      Also report errors for "stylelint-disable" comments that are not blocking
+      a lint warning. The process will exit with code ${EXIT_CODE_LINT_PROBLEM} if needless disables are found.
 
-      --report-invalid-scope-disables, --risd
+    --report-invalid-scope-disables, --risd
 
-        Report "stylelint-disable" comments that used for rules that don't exist
-        within the configuration object. The process will exit with code ${EXIT_CODE_LINT_PROBLEM} if invalid
-        scope disables are found.
+      Report "stylelint-disable" comments that used for rules that don't exist
+      within the configuration object. The process will exit with code ${EXIT_CODE_LINT_PROBLEM} if invalid
+      scope disables are found.
 
-      --report-descriptionless-disables, --rdd
+    --report-descriptionless-disables, --rdd
 
-        Report "stylelint-disable" comments without a description. The process will
-        exit with code ${EXIT_CODE_LINT_PROBLEM} if descriptionless disables are found.
+      Report "stylelint-disable" comments without a description. The process will
+      exit with code ${EXIT_CODE_LINT_PROBLEM} if descriptionless disables are found.
 
-      --max-warnings, --mw <number>
+    --max-warnings, --mw <number>
 
-        The number of warnings above which the process will exit with code ${EXIT_CODE_LINT_PROBLEM}.
-        Useful when setting "defaultSeverity" to "warning" and expecting the process
-        to fail on warnings (e.g. CI build).
+      The number of warnings above which the process will exit with code ${EXIT_CODE_LINT_PROBLEM}.
+      Useful when setting "defaultSeverity" to "warning" and expecting the process
+      to fail on warnings (e.g. CI build).
 
-      --output-file, -o <path>
+    --output-file, -o <path>
 
-        A file path to write a report.
+      A file path to write a report.
 
-      --allow-empty-input, --aei
+    --allow-empty-input, --aei
 
-        When a glob pattern matches no files, the process will exit without throwing an error.
+      When a glob pattern matches no files, the process will exit without throwing an error.
 
-      --suppress [<rule>]
-        Suppress problems and record them in a file. If no rule is specified,
-        all problems are suppressed. Otherwise, only problems with the given
-        rules are suppressed, e.g., "--suppress rule1 --suppress rule2".
-        See also "--suppress-location".
+    --suppress[=<rule>]
 
-      --suppress-location <path>
+      Suppress problems and record them in a file. If no rule is specified,
+      all problems are suppressed. Otherwise, only problems with the given
+      rules are suppressed, e.g., "--suppress=rule1 --suppress=rule2".
+      See also "--suppress-location".
 
-        A path to a file or directory to be used for the suppressions file location. If a
-        directory is specified, a suppressions file will be created inside the specified
-        folder, with the name "${DEFAULT_SUPPRESSION_FILENAME}".
+    --suppress-location <path>
 
-      --globby-options, --go <json>
+      A path to a file or directory to be used for the suppressions file location. If a
+      directory is specified, a suppressions file will be created inside the specified
+      folder, with the name "${DEFAULT_SUPPRESSION_FILENAME}".
 
-        Options in JSON format passed to globby.
+    --globby-options, --go <json>
 
-      --version, -v
+      Options in JSON format passed to globby.
 
-        Show the version.
+    --version, -v
 
-      --help, -h
+      Show the version.
 
-        Show the help.
+    --help, -h
+
+      Show the help.
 `;
 
+/**
+ * @typedef {object} Flag
+ * @property {'boolean' | 'number' | 'string'} type
+ * @property {string} [short] A one-character alias, e.g. `-c`.
+ * @property {string[]} [aliases] Long aliases, e.g. `--aei`.
+ * @property {boolean} [multiple] Whether the flag can repeat. Its values collect into an array, which is empty when the flag is unspecified.
+ * @property {boolean} [optionalValue] Whether the value can be omitted, as in `--fix[=<mode>]`.
+ * @property {boolean} [default] A flag without a default is absent when unspecified, so that the config property applies.
+ */
+
+/** @type {Record<string, Flag>} */
 const flags = {
 	allowEmptyInput: {
 		aliases: ['aei'],
@@ -243,12 +257,12 @@ const flags = {
 		type: 'boolean',
 	},
 	computeEditInfo: {
-		shortFlag: 'cei',
+		aliases: ['cei'],
 		type: 'boolean',
 		default: false,
 	},
 	config: {
-		shortFlag: 'c',
+		short: 'c',
 		type: 'string',
 	},
 	configBasedir: {
@@ -266,9 +280,10 @@ const flags = {
 	},
 	fix: {
 		type: 'string',
+		optionalValue: true,
 	},
 	formatter: {
-		shortFlag: 'f',
+		short: 'f',
 		type: 'string',
 	},
 	globbyOptions: {
@@ -276,7 +291,7 @@ const flags = {
 		type: 'string',
 	},
 	help: {
-		shortFlag: 'h',
+		short: 'h',
 		type: 'boolean',
 	},
 	ignoreDisables: {
@@ -284,28 +299,28 @@ const flags = {
 		type: 'boolean',
 	},
 	ignorePath: {
-		shortFlag: 'i',
+		short: 'i',
 		type: 'string',
-		isMultiple: true,
+		multiple: true,
 	},
 	ignorePattern: {
 		aliases: ['ip'],
 		type: 'string',
-		isMultiple: true,
+		multiple: true,
 	},
 	maxWarnings: {
 		aliases: ['mw'],
 		type: 'number',
 	},
 	outputFile: {
-		shortFlag: 'o',
+		short: 'o',
 		type: 'string',
 	},
 	printConfig: {
 		type: 'boolean',
 	},
 	quiet: {
-		shortFlag: 'q',
+		short: 'q',
 		type: 'boolean',
 	},
 	quietDeprecationWarnings: {
@@ -335,21 +350,39 @@ const flags = {
 	},
 	suppress: {
 		type: 'string',
-		isMultiple: true,
+		multiple: true,
+		optionalValue: true,
 	},
 	suppressLocation: {
 		type: 'string',
 	},
-
 	validate: {
 		type: 'boolean',
 		default: true,
 	},
 	version: {
-		shortFlag: 'v',
+		short: 'v',
 		type: 'boolean',
 	},
 };
+
+/**
+ * The `flags` entry for every option name the command line accepts: the kebab-case name and the aliases of each flag.
+ * @type {Map<string, [name: string, flag: Flag]>}
+ */
+const flagEntriesByOption = new Map(
+	Object.entries(flags).flatMap(([name, flag]) =>
+		[kebabCase(name), ...(flag.aliases ?? [])].map((option) => [option, [name, flag]]),
+	),
+);
+
+/** @type {Record<string, ParseArgsOption>} */
+const parseArgsOptions = Object.fromEntries(
+	[...flagEntriesByOption].map(([option, [name, flag]]) => [
+		option,
+		buildParseArgsOption(option, name, flag),
+	]),
+);
 
 /**
  * @param {string[]} argv
@@ -358,7 +391,10 @@ const flags = {
 export default async function main(argv) {
 	const cli = buildCLI(argv);
 
-	const invalidOptionsMessage = checkInvalidCLIOptions(flags, cli.flags);
+	const invalidOptionsMessage = checkInvalidCLIOptions(
+		[...flagEntriesByOption.keys()],
+		cli.optionNames,
+	);
 
 	if (invalidOptionsMessage) {
 		process.stderr.write(invalidOptionsMessage);
@@ -403,8 +439,6 @@ export default async function main(argv) {
 		version,
 	} = cli.flags;
 
-	const showHelp = () => cli.showHelp(EXIT_CODE_SUCCESS);
-
 	if (help) {
 		showHelp();
 
@@ -412,7 +446,7 @@ export default async function main(argv) {
 	}
 
 	if (version) {
-		cli.showVersion();
+		process.stdout.write(`${getPackageJSON().version}${EOL}`);
 
 		return;
 	}
@@ -508,12 +542,6 @@ export default async function main(argv) {
 
 	if (isString(fix)) {
 		options.fix = normalizeFixMode(fix);
-
-		// If the fix argument is unknown, consider it as an input path.
-		if (options.fix === undefined) {
-			options.fix = DEFAULT_FIX_MODE;
-			cli.input.push(fix);
-		}
 	}
 
 	if (isBoolean(validate)) {
@@ -548,16 +576,17 @@ export default async function main(argv) {
 		options.computeEditInfo = computeEditInfo;
 	}
 
-	// Handle suppress logic - detect both --suppress (all) and --suppress=rule cases
-	const hasPlainSuppress = argv.includes('--suppress');
-	const hasRuleSuppress = Array.isArray(suppress) && suppress.length > 0;
+	// A bare `--suppress` parses as the empty string and suppresses all problems; `--suppress=<rule>` suppresses those of the rule.
+	if (Array.isArray(suppress)) {
+		if (suppress.includes('')) {
+			options.suppressAll = true;
+		}
 
-	if (hasPlainSuppress) {
-		options.suppressAll = true;
-	}
+		const suppressRule = suppress.filter((rule) => rule !== '');
 
-	if (hasRuleSuppress) {
-		options.suppressRule = suppress;
+		if (suppressRule.length > 0) {
+			options.suppressRule = suppressRule;
+		}
 	}
 
 	if (isString(suppressLocation)) {
@@ -719,29 +748,96 @@ async function importCustomFormatter(fileOrModulePath) {
 }
 
 /**
+ * @returns {void}
+ */
+function showHelp() {
+	process.stdout.write(`\n  ${getPackageJSON().description}\n${helpText}`);
+}
+
+/**
+ * @returns {{ description: string, version: string }}
+ */
+function getPackageJSON() {
+	return JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+}
+
+/**
+ * Converts a flag name to its option name, e.g. `allowEmptyInput` to `allow-empty-input`.
+ * @param {string} name
+ * @returns {string}
+ */
+function kebabCase(name) {
+	return name.replaceAll(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+}
+
+/**
+ * @param {string} option
+ * @param {string} name
+ * @param {Flag} flag
+ * @returns {ParseArgsOption}
+ */
+function buildParseArgsOption(option, name, flag) {
+	return {
+		// A flag with an optional value is declared boolean, as a string option would take the next argument as its value.
+		type: flag.type === 'boolean' || flag.optionalValue ? 'boolean' : 'string',
+		...(flag.multiple && { multiple: true }),
+		// Only the kebab-case option name carries the short flag, so that parseArgs reports the short flag under that name.
+		...(isString(flag.short) && option === kebabCase(name) && { short: flag.short }),
+	};
+}
+
+/**
+ * @param {Flag} flag
+ * @param {string | boolean | undefined} value
+ * @returns {string | number | boolean | undefined}
+ */
+function normalizeFlagValue(flag, value) {
+	if (flag.type === 'boolean') {
+		// `--cache=false`
+		return isString(value) ? value !== 'false' : value;
+	}
+
+	if (value === true) {
+		// A flag given without a value has the empty string when its value is optional, as in a bare `--fix`, and no value otherwise.
+		return flag.optionalValue ? '' : undefined;
+	}
+
+	return flag.type === 'number' && isString(value) ? Number(value) : value;
+}
+
+/**
  * @param {string[]} argv
+ * @returns {{ flags: Record<string, unknown>, input: string[], optionNames: string[] }}
  */
 export function buildCLI(argv) {
-	return meow(helpText, {
-		autoHelp: false,
-		autoVersion: false,
-		argv,
-
-		// NOTE: `meow()` infers flag types when passing a flag object with inline.
-		// However, `checkInvalidCLIOptions()` also needs this flag object.
-		// So, unfortunately, the return value type inference by `meow()` is unavailable here.
-		//
-		// @ts-expect-error -- TS2322: Type '{ allowEmptyInput: {...} }' is not assignable to type 'AnyFlags'.
-		flags,
-
-		// NOTE: We must enable `allowUnknownFlags` because meow exits with `2` if `allowUnknownFlags` is disabled.
-		// Instead, we use our different exit code with `checkInvalidCLIOptions()`.
-		// See also https://github.com/sindresorhus/meow/blob/v12.0.1/source/validate.js#L75
-		allowUnknownFlags: true,
-
-		// NOTE: If CLI flags are unspecified (e.g., `--cache` nor `--no-cache`), we want to fall back to config properties (e.g., `cache`).
-		booleanDefault: undefined,
-
-		importMeta: import.meta,
+	const { values, positionals } = parseArgs({
+		args: argv,
+		options: parseArgsOptions,
+		strict: false, // Unknown flags are reported by `checkInvalidCLIOptions()` instead
+		allowPositionals: true,
+		allowNegative: true,
 	});
+
+	/** @type {Record<string, unknown>} */
+	const parsedFlags = Object.fromEntries(
+		Object.entries(flags)
+			.map(([name, flag]) => [name, flag.multiple ? [] : flag.default])
+			.filter(([, value]) => value !== undefined),
+	);
+
+	for (const [option, value] of Object.entries(values)) {
+		const flagEntry = flagEntriesByOption.get(option);
+
+		if (flagEntry === undefined) {
+			continue;
+		}
+
+		const [name, flag] = flagEntry;
+
+		parsedFlags[name] = Array.isArray(value)
+			? value.map((entry) => normalizeFlagValue(flag, entry)).filter(isString)
+			: normalizeFlagValue(flag, value);
+	}
+
+	return { flags: parsedFlags, input: positionals, optionNames: Object.keys(values) };
 }

--- a/lib/utils/__tests__/checkInvalidCLIOptions.test.mjs
+++ b/lib/utils/__tests__/checkInvalidCLIOptions.test.mjs
@@ -6,25 +6,10 @@ import picocolors from 'picocolors';
 const { red: r, cyan: c } = picocolors;
 
 describe('checkInvalidCLIOptions', () => {
-	const allowedOptions = {
-		fix: {},
-		config: {},
-		maxWar: { alias: 'mw' },
-		quiet: { alias: 'q' },
-	};
+	const allowedOptions = ['fix', 'config', 'max-war', 'mw', 'quiet', 'q'];
 
 	it('returns a message when check fails', () => {
-		const inputOptions = {
-			fis: true,
-			fi: true,
-			fixx: true,
-			aix: true,
-			conig: true,
-			mxWar: true,
-			ma: true,
-			q: true,
-			o: true,
-		};
+		const inputOptions = ['fis', 'fi', 'fixx', 'aix', 'conig', 'mx-war', 'ma', 'q', 'o'];
 
 		expect(checkInvalidCLIOptions(allowedOptions, inputOptions)).toBe(
 			`Invalid option ${r('"--fis"')}. Did you mean ${c('"--fix"')}?
@@ -40,16 +25,9 @@ Invalid option ${r('"-o"')}.
 	});
 
 	it('returns an empty string when check succeeds', () => {
-		expect(checkInvalidCLIOptions(allowedOptions, {})).toBe('');
+		expect(checkInvalidCLIOptions(allowedOptions, [])).toBe('');
 		expect(
-			checkInvalidCLIOptions(allowedOptions, {
-				fix: true,
-				config: true,
-				maxWar: true,
-				mw: true,
-				quiet: true,
-				q: true,
-			}),
+			checkInvalidCLIOptions(allowedOptions, ['fix', 'config', 'max-war', 'mw', 'quiet', 'q']),
 		).toBe('');
 	});
 });

--- a/lib/utils/checkInvalidCLIOptions.mjs
+++ b/lib/utils/checkInvalidCLIOptions.mjs
@@ -7,24 +7,6 @@ import levenshteinDistance from './levenshteinDistance.mjs';
 const { cyan, red } = picocolors;
 
 /**
- * @param {{ [key: string]: { alias?: string } }} allowedOptions
- * @returns {string[]}
- */
-const buildAllowedOptions = (allowedOptions) => {
-	const options = Object.keys(allowedOptions);
-
-	for (const { alias } of Object.values(allowedOptions)) {
-		if (alias) {
-			options.push(alias);
-		}
-	}
-
-	options.sort();
-
-	return options;
-};
-
-/**
  * @param {string[]} all
  * @param {string} invalid
  * @returns {null|string}
@@ -44,22 +26,6 @@ const suggest = (all, invalid) => {
 };
 
 /**
- * Converts a string to kebab case.
- * For example, `kebabCase('oneTwoThree') === 'one-two-three'`.
- * @param {string} opt
- * @returns {string}
- */
-const kebabCase = (opt) => {
-	const matches = opt.match(/[A-Z]?[a-z]+|[A-Z]|[0-9]+/g);
-
-	if (matches) {
-		return matches.map((s) => s.toLowerCase()).join('-');
-	}
-
-	return '';
-};
-
-/**
  * @param {string} opt
  * @returns {string}
  */
@@ -68,7 +34,7 @@ const cliOption = (opt) => {
 		return `"-${opt}"`;
 	}
 
-	return `"--${kebabCase(opt)}"`;
+	return `"--${opt}"`;
 };
 
 /**
@@ -87,16 +53,15 @@ const buildMessageLine = (invalid, suggestion) => {
 };
 
 /**
- * @param {{ [key: string]: any }} allowedOptions
- * @param {{ [key: string]: any }} inputOptions
+ * @param {string[]} allowedOptions Option names as typed on the command line, without dashes, e.g. `max-warnings`.
+ * @param {string[]} inputOptions
  * @returns {string}
  */
 export default function checkInvalidCLIOptions(allowedOptions, inputOptions) {
-	const allOptions = buildAllowedOptions(allowedOptions);
+	const allOptions = allowedOptions.toSorted();
 
-	return Object.keys(inputOptions)
+	return inputOptions
 		.filter((opt) => !allOptions.includes(opt))
-		.map((opt) => kebabCase(opt))
 		.reduce((msg, invalid) => {
 			// NOTE: No suggestion for shortcut options because it's too difficult
 			const suggestion = invalid.length >= 2 ? suggest(allOptions, invalid) : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "globjoin": "^0.1.4",
         "ignore": "^7.0.8",
         "import-meta-resolve": "^4.2.0",
-        "meow": "^14.1.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
@@ -7448,18 +7447,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/meow": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "globjoin": "^0.1.4",
     "ignore": "^7.0.8",
     "import-meta-resolve": "^4.2.0",
-    "meow": "^14.1.0",
     "micromatch": "^4.0.8",
     "normalize-path": "^3.0.0",
     "picocolors": "^1.1.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of our efforts to reduce dependencies.

> Is there anything in the PR that needs further explanation?

I've been digging into our non-dev dependencies over the past couple of days.

Like https://github.com/stylelint/stylelint/pull/9500, this PR explores another potential modernisation. This time for our CLI builder.

We use [`meow`](https://npmx.dev/package/meow), which adds 428 KB to the install size and 25 ms to each invocation.

This PR removes it in favour of a small wrapper around [`node:util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig), specific to our needs.

The diff is relatively small if we ignore the indentation change for help text, and it feels like a net simplification of the code.

The 3 behavioural changes seem minor, and I've documented them in the migration guide.

I ran a couple of benchmarks with [hyperfine](https://github.com/sharkdp/hyperfine):

Command | Before | Now | Saved | Gain
-- | -- | -- | -- | --
stylelint --version | 141.0 ms | 110.9 ms | 30.1 ms | 21%
lint one fixture file | 158.6 ms | 129.1 ms | 29.5 ms | 19%

